### PR TITLE
modifications for integrations with saturn backend

### DIFF
--- a/proxy-server/minikube-mock-auth.yaml
+++ b/proxy-server/minikube-mock-auth.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    run: mock-auth-server
+  name: mock-auth-server
+spec:
+  ports:
+  - port: 8888
+    protocol: TCP
+    targetPort: 8888
+  selector:
+    run: mock-auth-server
+  type: NodePort
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: mock-auth-server
+  name: mock-auth-server
+spec:
+  containers:
+  - image: mock-auth-server:test
+    imagePullPolicy: IfNotPresent
+    name: auth
+    ports:
+    - containerPort: 8888
+      protocol: TCP
+  dnsPolicy: ClusterFirst

--- a/proxy-server/minikube-test.sh
+++ b/proxy-server/minikube-test.sh
@@ -3,6 +3,8 @@
 which docker > /dev/null || (echo "docker is not installed. Exiting." && exit 1)
 which minikube > /dev/null || (echo "minikube is not installed. Exiting." && exit 1)
 
+PROXY_AUTH=${PROXY_AUTH:-"false"}
+
 eval $(minikube docker-env)
 
 echo -e "\033[1;92mBuilding proxy image\033[0m"
@@ -12,14 +14,21 @@ echo -e "\033[1;92mBuilding test server image\033[0m"
 (cd test && docker build -t mock-auth-server:test .)
 
 kubectl apply -f minikube-test.yaml
+if $PROXY_AUTH; then
+    kubectl apply -f minikube-mock-auth.yaml
+fi
 
 echo "Waiting for all pods to be ready..."
-kubectl wait --for=condition=Ready pod/mock-auth-server
+if $PROXY_AUTH; then
+    kubectl wait --for=condition=Ready pod/mock-auth-server
+fi
 kubectl wait --for=condition=Ready pod/proxy-test
 
-kubectl port-forward svc/mock-auth-server 8888:8888 &
-auth_pid=$!
-sleep 0.1
+if $PROXY_AUTH; then
+    kubectl port-forward svc/mock-auth-server 8888:8888 &
+    auth_pid=$!
+    sleep 0.1
+fi
 
 
 
@@ -29,7 +38,9 @@ echo "
 Open this URL in your browser: $(minikube service proxy-test --url=true)/
 "
 
-read -p "Press any key to stop forwarding and tear down resources."
+read -p "Press any key to tear down resources."
 
-kill $auth_pid || true # let deletion occur when there was an issue with port-forwarding
+if $PROXY_AUTH; then
+    kill $auth_pid || true # let deletion occur when there was an issue with port-forwarding
+fi
 kubectl delete -f minikube-test.yaml

--- a/proxy-server/minikube-test.yaml
+++ b/proxy-server/minikube-test.yaml
@@ -32,9 +32,11 @@ spec:
       - name: PROXY_LISTEN_PORT
         value: "8080"
       - name: PROXY_TARGET_URL
-        value: "http://web-resource:80"
+        value: "http://web-resource.default.svc.cluster.local:80"
       - name: PROXY_FALLBACK_URL
-        value: "http://localhost:8888/"
+        value: "http://dev.localtest.me:8888/auth/login"
+      - name: HTTPS_SELF_REDIRECT
+        value: "false"
       - name: PROXY_DEBUG
         value: "true"
   dnsPolicy: ClusterFirst
@@ -67,36 +69,5 @@ spec:
     name: web
     ports:
     - containerPort: 80
-      protocol: TCP
-  dnsPolicy: ClusterFirst
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    run: mock-auth-server
-  name: mock-auth-server
-spec:
-  ports:
-  - port: 8888
-    protocol: TCP
-    targetPort: 8888
-  selector:
-    run: mock-auth-server
-  type: NodePort
----
-apiVersion: v1
-kind: Pod
-metadata:
-  labels:
-    run: mock-auth-server
-  name: mock-auth-server
-spec:
-  containers:
-  - image: mock-auth-server:test
-    imagePullPolicy: IfNotPresent
-    name: auth
-    ports:
-    - containerPort: 8888
       protocol: TCP
   dnsPolicy: ClusterFirst

--- a/proxy-server/test/auth_server.py
+++ b/proxy-server/test/auth_server.py
@@ -52,7 +52,7 @@ class HTTPServerHandler(BaseHTTPRequestHandler):
         query_components = parse_qs(urlparse(self.path).query)
 
         ret_token = query_components.get("ret_token")
-        orig_request = query_components.get("orig_request")
+        orig_request = query_components.get("next")
         if (
             ret_token is not None
             and len(ret_token) > 0


### PR DESCRIPTION
Summary of changes:
1. Changed `orig_request` to `next` to match saturn's convention
2. Added protocol to return URL (the proxy can't detect which to use automatically because it's always `http://` behind the ingress - controlled by env var that defaults to `https`, meaning we just need to set it for local testing, as is done in the yaml here)
3. Split mock auth and proxy test into separate files - if `PROXY_AUTH=true` is not passed to `./minikube-test.sh`, the mock auth server will not be set up, nor forwarded to. The yaml now defaults to `dev.localhost.me:8888` with the assumption that a valid saturn backend is running there.