### PR TITLE
Assorted fixes/enhancements

### DIFF
--- a/proxy-server/minikube-test.sh
+++ b/proxy-server/minikube-test.sh
@@ -4,6 +4,7 @@ which docker > /dev/null || (echo "docker is not installed. Exiting." && exit 1)
 which minikube > /dev/null || (echo "minikube is not installed. Exiting." && exit 1)
 
 PROXY_AUTH=${PROXY_AUTH:-"false"}
+WEB_HOSTNAME="web.localtest.me"
 
 eval $(minikube docker-env)
 
@@ -35,7 +36,8 @@ fi
 echo -e "\033[1;92mReady for test\033[0m"
 
 echo "
-Open this URL in your browser: $(minikube service proxy-test --url=true)/
+Open this URL in your browser: http://${WEB_HOSTNAME}/
+(you'll need to map web.localtest.me to $(minikube ip) in /etc/hosts if you haven't already)
 "
 
 read -p "Press any key to tear down resources."

--- a/proxy-server/minikube-test.sh
+++ b/proxy-server/minikube-test.sh
@@ -11,8 +11,10 @@ eval $(minikube docker-env)
 echo -e "\033[1;92mBuilding proxy image\033[0m"
 docker build -t proxy-server:test .
 
-echo -e "\033[1;92mBuilding test server image\033[0m"
-(cd test && docker build -t mock-auth-server:test .)
+if $PROXY_AUTH; then
+    echo -e "\033[1;92mBuilding test server image\033[0m"
+    (cd test && docker build -t mock-auth-server:test .)
+fi
 
 kubectl apply -f minikube-test.yaml
 if $PROXY_AUTH; then

--- a/proxy-server/minikube-test.yaml
+++ b/proxy-server/minikube-test.yaml
@@ -39,7 +39,28 @@ spec:
         value: "false"
       - name: PROXY_DEBUG
         value: "true"
+      - name: PROXY_SUFFIX
+        value: ".localtest.me"
+      - name: PROXY_CONFIG
+        value: "/etc/config/proxy.json"
+    volumeMounts:
+    - name: config-volume
+      mountPath: /etc/config
+  volumes:
+  - name: config-volume
+    configMap:
+      name: proxy-test-config
   dnsPolicy: ClusterFirst
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: proxy-test-config
+data:
+  proxy.json: |
+    {
+      "web":"http://web-resource.default.svc.cluster.local:80"
+    }
 ---
 apiVersion: v1
 kind: Service
@@ -71,3 +92,16 @@ spec:
     - containerPort: 80
       protocol: TCP
   dnsPolicy: ClusterFirst
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web-resource
+spec:
+  rules:
+    - host: web.localtest.me
+      http:
+        paths:
+        - backend:
+            serviceName: proxy-test
+            servicePort: 80

--- a/proxy-server/proxy-server.go
+++ b/proxy-server/proxy-server.go
@@ -197,7 +197,8 @@ func redirectToFallBack(res http.ResponseWriter, req *http.Request, error int, o
 		log.Printf("Redirecting to fallback url: %s", u)
 	}
 
-	http.Redirect(res, req, u, 301)
+	res.Header().Add("Cache-Control", "no-cache")
+	http.Redirect(res, req, u, 302)
 }
 
 // Given a request send it to the appropriate url
@@ -254,7 +255,8 @@ func handleRequestAndRedirect(res http.ResponseWriter, req *http.Request) {
 			q := req.URL.Query()
 			q.Del("saturn_token")
 			req.URL.RawQuery = q.Encode()
-			http.Redirect(res, req, req.URL.String(), 301)
+			res.Header().Add("Cache-Control", "no-cache")
+			http.Redirect(res, req, req.URL.String(), 302)
 			log.Printf("OK: Redirecting to self (%s)", req.URL.String())
 			return
 		}


### PR DESCRIPTION
Summary of changes:

- `./minikube-test.sh` should now work out of the box again (as well as it did before, at least)
- most error cases now print a human-readable message when returned to the user (except for in the event of `panic()` - golang's `http` seems to throw away the response in this case, leaving minikube to respond 502 via openresty. if this is something we decide we want to fix, we can do `recover()` + some custom stack printing - I decided that was getting too into the weeds for this PR)
- `extractTargetURLKey` no longer panics when responding via IP and not hostname
- the user is now given an error if signing the cookie somehow fails
- no more lint warnings