### PR TITLE
cut image size for daskdev-sat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# images
+
+This repository holds code to create Saturn Docker images.
+
+## Adding a new image definition
+
+Each image is stored in its own subdirectory. That subdirectory should have at least a `Dockerfile` and `.dockerignore`.
+
+**`Dockerfile`**
+
+A script that defines how to build the image.
+
+For complete details on how to write `.dockerignore` files, see [the official docker documentation](https://docs.docker.com/engine/reference/builder/).
+
+**`.dockerignore`**
+
+Similar to `.gitignore`, `.dockerignore` is used to prevent unwanted files from being bundled in an image. For a good explanation of this, see ["Do Not Ignore .dockerignore"](https://codefresh.io/docker-tutorial/not-ignore-dockerignore-2/).
+
+The images in this repository use `.dockerignore` files like this:
+
+```text
+*
+!app.py
+!environment.yml
+```
+
+That syntax says "ignore everything EXCEPT `app.py` and `environment.yml`".
+
+For complete details on how to write `.dockerignore` files, see [the docker documentation](https://docs.docker.com/engine/reference/builder/#dockerignore-file).

--- a/daskdev-sat/.dockerignore
+++ b/daskdev-sat/.dockerignore
@@ -1,0 +1,3 @@
+*
+!app.py
+!environment.yaml

--- a/daskdev-sat/Dockerfile
+++ b/daskdev-sat/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get -qq update && \
 ENV SHELL /bin/bash
 
 RUN conda install -y -c conda-forge distributed tornado kubernetes dask-kubernetes python-kubernetes
-RUN conda install -y -c https://conda.saturncloud.io/pkgs sutils=0.5.1
+RUN conda install -y -c https://conda.saturncloud.io/pkgs sutils=0.5.1 && \
+    conda clean --yes --all
 
 #TODO - remove this pdc crap
 #TODO - run as non-root user

--- a/gitea/.dockerignore
+++ b/gitea/.dockerignore
@@ -1,0 +1,2 @@
+*
+!admin_create_user.sh

--- a/saturn-gpu/.dockerignore
+++ b/saturn-gpu/.dockerignore
@@ -1,0 +1,2 @@
+*
+!environment.yaml

--- a/saturn-r/.dockerignore
+++ b/saturn-r/.dockerignore
@@ -1,0 +1,2 @@
+*
+!install.R

--- a/saturn/.dockerignore
+++ b/saturn/.dockerignore
@@ -1,0 +1,2 @@
+*
+!environment.yaml

--- a/saturnbase-gpu/.dockerignore
+++ b/saturnbase-gpu/.dockerignore
@@ -1,0 +1,4 @@
+*
+!environment.yml
+!install-jupyter.bash
+!install-miniconda.bash

--- a/saturnbase/.dockerignore
+++ b/saturnbase/.dockerignore
@@ -1,0 +1,4 @@
+*
+!environment.yml
+!install-jupyter.bash
+!profile


### PR DESCRIPTION
This PR cuts about 50 MB out of the `daskdev-sat` image with `conda clean`, and adds `.dockerignore` for images that don't have them, to keep unwanted files lying around at build time out of those images.
