### PR TITLE
Include dask-labextension in jupyter env

### DIFF
--- a/saturn/Dockerfile
+++ b/saturn/Dockerfile
@@ -9,3 +9,8 @@ RUN conda env update -n saturn --file /tmp/environment.yml && \
     find ${CONDA_DIR} -type f,l -name '*.a' -delete && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete
 RUN echo '' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+RUN ${CONDA_DIR}/bin/conda install -n root -c saturncloud dask-labextension "dask-saturn=0.0.2" "dask=2.12.0" "distributed=2.12.0"
+
+RUN ${CONDA_DIR}/bin/jupyter labextension install dask-labextension
+RUN ${CONDA_DIR}/bin/jupyter serverextension enable --py dask_labextension --sys-prefix
+


### PR DESCRIPTION
It works to include the import and extension install in this dockerfile, but it is kind of odd that the jupyter env is different from the kernel env. I don't want to include dask-labextension in saturnbase since that would require that bokeh, dask, distributed and so on also be in base. 

Related PRs: saturncloud/dask-saturn#8, https://github.com/saturncloud/saturn/pull/398