### PR TITLE
Update to proxy authentication when a refresh token is present

### DIFF
--- a/proxy-server/Dockerfile
+++ b/proxy-server/Dockerfile
@@ -12,9 +12,6 @@ COPY --from=0 /app/proxy-server /app/proxy-server
 COPY etc/nsswitch.conf /etc/nsswitch.conf
 
 ENV PROXY_LISTEN_PORT=8080
-ENV PROXY_FALLBACK_URL=http://localhost:$PROXY_LISTEN_PORT/fallback
-ENV PROXY_RESOURCE_URL=http://localhost:80
-ENV JWT_EXPIRE_SEC=3600
 
 EXPOSE 8080
 

--- a/proxy-server/Dockerfile
+++ b/proxy-server/Dockerfile
@@ -9,11 +9,12 @@ RUN go build .
 FROM alpine:latest
 
 COPY --from=0 /app/proxy-server /app/proxy-server
+COPY etc/nsswitch.conf /etc/nsswitch.conf
 
 ENV PROXY_LISTEN_PORT=8080
 ENV PROXY_FALLBACK_URL=http://localhost:$PROXY_LISTEN_PORT/fallback
 ENV PROXY_RESOURCE_URL=http://localhost:80
-ENV JWT_MINUTES_EXPIRE=60
+ENV JWT_EXPIRE_SEC=3600
 
 EXPOSE 8080
 

--- a/proxy-server/etc/nsswitch.conf
+++ b/proxy-server/etc/nsswitch.conf
@@ -1,0 +1,1 @@
+hosts: files dns

--- a/proxy-server/local.sh
+++ b/proxy-server/local.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+usage() {
+    echo '
+    Usage:
+        Commands:
+            build: Build image, push to local registry, and set image on saturn-auth-proxy deployment(s)
+        Options:
+            -n, --namespace: Namespace(s) to update (default: "main-namespace anon-namespace"
+            --tail: Tail logs after deploying new image. If multiple namepsaces are specified by namespace param (e.g. default),
+                    you may pass a single namespace to tail with this param.
+
+    Examples:
+        # Set new image only in main, and tail logs
+        ./local.sh build -n main-namespace --tail
+
+        # Set new image in both namesapces, and tail the proxy in main
+        ./local.sh build --tail main-namespace
+'
+}
+
+NAMESPACES="main-namespace anon-namespace"
+TAIL=""
+TAIL_NS=""
+while [ "$1" ]; do
+    case $1 in
+        build )
+            COMMAND=$1
+            ;;
+        -n | --namespace )
+            shift
+            NAMESPACES="$1"
+            ;;
+        --tail )
+            if [[ $2 != -* ]]; then
+                shift
+                TAIL_NS=$1
+            fi
+            TAIL=true
+            ;;
+        * )
+            echo "Error: Unkown parameter \"$1\""
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+header() {
+    echo -e "\n${@}"
+    DASHES=$(( $(echo "${@}" | wc -c) * 2 ))
+    for i in $(seq $DASHES); do
+        echo -n "-"
+    done
+    echo
+}
+
+if [ ! "$COMMAND" ]; then
+    echo "Error: Missing <COMMAND>"
+    exit 1
+fi
+
+NUM_NAMESPACES=$(echo $NAMESPACES | wc -w)
+if [ "$TAIL" ] && [ ! "$TAIL_NS" ] && (( $NUM_NAMESPACES > 1 )); then
+    echo "Error: Unable to tail proxy in multiple namespaces. Specify a namespace."
+elif [ ! "$TAIL_NS" ] && (( $NUM_NAMESPACES == 1 )); then
+    TAIL_NS=$NAMESPACES
+fi
+
+DIR=$(dirname $0)
+
+IMAGE=localhost:32000/proxy-server
+TAG_PREFIX=test
+
+LATEST_TAG=$(docker images | grep $IMAGE | head -n 1 | awk '{print $2}')
+TAG="$TAG_PREFIX$(($(echo $LATEST_TAG | sed 's/'$TAG_PREFIX'//') + 1))"
+
+header Build
+docker build -t $IMAGE:$TAG $DIR
+
+OLD_ID=$(docker inspect --format {{.Id}} $IMAGE:$LATEST_TAG)
+NEW_ID=$(docker inspect --format {{.Id}} $IMAGE:$TAG)
+
+if [ "$OLD_ID" == "$NEW_ID" ]; then
+    echo -e "\nNo changes from previous build"
+    docker rmi $IMAGE:$TAG
+    TAG=$LATEST_TAG
+else
+    header Push
+    docker push $IMAGE:$TAG
+fi
+
+header Rollout
+for NS in $NAMESPACES; do
+    kubectl -n $NS set image deployment/saturn-auth-proxy --record proxy=$IMAGE:$TAG
+done
+
+if [ "$TAIL" ]; then
+    kubectl -n $TAIL_NS rollout status deployment saturn-auth-proxy
+    header Logs
+    kubectl -n $TAIL_NS logs -f deployment/saturn-auth-proxy
+fi

--- a/proxy-server/local.sh
+++ b/proxy-server/local.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 usage() {
     echo '
@@ -72,7 +73,7 @@ DIR=$(dirname $0)
 IMAGE=localhost:32000/proxy-server
 TAG_PREFIX=test
 
-LATEST_TAG=$(docker images | grep $IMAGE | head -n 1 | awk '{print $2}')
+LATEST_TAG=$(docker images | grep "$IMAGE" |  awk 'NR==1{print $2}')
 TAG="$TAG_PREFIX$(($(echo $LATEST_TAG | sed 's/'$TAG_PREFIX'//') + 1))"
 
 header Build

--- a/proxy-server/proxy-server.go
+++ b/proxy-server/proxy-server.go
@@ -390,7 +390,7 @@ func handleRequestAndRedirect(res http.ResponseWriter, req *http.Request) {
 
 		claims, err := validateSaturnToken(satToken, jwtPrincipals.Atlas, req)
 		if err != nil {
-			fmt.Printf("Authorization Erorr: %s", err)
+			fmt.Printf("Authorization Error: %s", err)
 			respondWithError(res, http.StatusUnauthorized, "Invalid token.")
 			return
 		}

--- a/proxy-server/proxy-server.go
+++ b/proxy-server/proxy-server.go
@@ -195,7 +195,7 @@ type SaturnClaims struct {
 /*
 	Create JWT for proxy authentication or auth refresh
 */
-func createToken(host, username string, expiration time.Time, refreshToken bool) (string, error) {
+func createToken(host, user_id string, expiration time.Time, refreshToken bool) (string, error) {
 	var audience string
 	var key []byte
 	if refreshToken {
@@ -213,7 +213,7 @@ func createToken(host, username string, expiration time.Time, refreshToken bool)
 			Audience:  audience,
 			ExpiresAt: expiration.Unix(),
 			Issuer:    jwtPrincipals.SaturnAuthProxy,
-			Subject:   username,
+			Subject:   user_id,
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -228,10 +228,10 @@ func createToken(host, username string, expiration time.Time, refreshToken bool)
 /*
 	Create new JWT cookies for session auth and refresh token
 */
-func setNewCookies(res http.ResponseWriter, req *http.Request, username string) error {
+func setNewCookies(res http.ResponseWriter, req *http.Request, user_id string) error {
 	// Create a new refresh_token
 	refreshExpiration := time.Now().Add(time.Duration(refreshTokenExpirationSeconds) * time.Second)
-	refreshTokenString, err := createToken(req.Host, username, refreshExpiration, true)
+	refreshTokenString, err := createToken(req.Host, user_id, refreshExpiration, true)
 	if err != nil {
 		return err
 	}
@@ -244,7 +244,7 @@ func setNewCookies(res http.ResponseWriter, req *http.Request, username string) 
 
 	// Create a new saturn_token
 	expirationTime := time.Now().Add(time.Duration(saturnTokenExpirationSeconds) * time.Second)
-	tokenString, err := createToken(req.Host, username, expirationTime, false)
+	tokenString, err := createToken(req.Host, user_id, expirationTime, false)
 	if err != nil {
 		return err
 	}

--- a/proxy-server/proxy-server.go
+++ b/proxy-server/proxy-server.go
@@ -469,6 +469,10 @@ func handleRequestAndRedirect(res http.ResponseWriter, req *http.Request) {
 /*
 	Check authorization header validity for the requested resource. Returns true if no error has been thrown.
 	If false is returned, the caller should assume that a response has already been written out.
+
+	This is used only for customers to access their deployments via Authorization header with a fixed token,
+	(e.g. for creating automation against a deployment) so that they don't have to mess with cookies and token
+	expiration.
 */
 func checkTokenAuth(res http.ResponseWriter, req *http.Request, authHeader string) bool {
 	target := extractTargetURLKey(req.Host)


### PR DESCRIPTION
Due to issues with CORS, it is difficult to handle Jupyter authentication by redirection. Especially given that we do not directly control the client-side application, which uses xhr requests and websockets (any of which may need to refresh the saturn_token at any given point in time). XHR requests don't send cookies by default even when you use the proper CORS headers on the backend, and while websockets can redirect in theory it is up to the client-side implementaion (surprise, 302 makes Jupyter unhappy).

All that is to say, it was a big mess to try to get the existing redirection system to work, so I set it up to do authentication by proxy instead when there is a valid session token in the initial client request. This ended up simplifying a lot of things, and greatly reduces the number of client redirects.

As per the discussion in the related Atlas PR (see below), add the concept of a refresh_token which is a signed JWT token that is only valid for a single user and domain. The refresh token can be used to retrieve a new saturn_token for the same user and domain, if the user still has access.

Also added some other nice things while I worked, like:
- changed the JWT_EXPIRE_MIN env var to SATURN_TOKEN_EXPIRE_SEC instead of minutes to match the format used in Atlas for JWT expiry and to help distinguish from the REFRESH_TOKEN_EXPIRE_SEC
- added a `local.sh` scripts to build a test image, push to local microk8s registry, and update the image on the saturn-auth-proxy deployments
- Added `/etc/nsswitch.conf` to the proxy-server image to enable it to communicate directly with the Atlas server in dev (which requires an entry to /etc/hosts, and was being ignored due to the lack of an nsswitch.conf)
- General cleanup of error handling, validation, etc.
- Renamed ret_token to redirect_token to make it clear what it is used for
- Using JWT issuer and audience for their traditional purposes, extended standard JWT claims to add Resource and RedirectToken fields

Related Atlas PR: https://github.com/saturncloud/saturn/pull/837