### PR TITLE
add tests on Python code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+name: Linting and Unit Tests
+
+# only run this workflow on new commits to main
+# or PRs into main
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+  schedule:
+    # Run every Monday morning at 11:00a UTC, 6:00a CST
+    - cron: '0 11 * * 1'
+
+jobs:
+  test:
+    name: ${{ matrix.task }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - task: linting
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        if: matrix.task != 'todo-checks'
+        uses: s-weigand/setup-conda@v1.0.3
+        with:
+          python-version: 3.7
+      - name: linting
+        if: matrix.task == 'linting'
+        shell: bash
+        run: |
+          pip install --upgrade black flake8 mypy
+          make lint

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,12 @@
 cpu_image:
 	bash scripts/build_cpu.sh
+
+.PHONY: format
+format:
+	black --line-length 100 .
+
+.PHONY: lint
+lint:
+	flake8 --count --max-line-length 100
+	black --check --diff --line-length 100 .
+	mypy --ignore-missing-imports .

--- a/daskdev-sat/app.py
+++ b/daskdev-sat/app.py
@@ -1,7 +1,7 @@
 import json
+import logging
 import os
 import yaml
-import logging
 
 import tornado.ioloop
 from tornado.web import RequestHandler, Application
@@ -43,12 +43,13 @@ def make_cluster(n_workers):
         deploy_mode="remote",
         name=NAME,
         namespace=NAMESPACE,
-        dashboard_link=DASHBOARD_LINK
+        dashboard_link=DASHBOARD_LINK,
     )
 
 
 class SaturnKubeCluster(KubeCluster):
     """Class that inherits from dask-kubernetes cluster"""
+
     def __init__(self, *args, dashboard_link=None, **kwargs):
         """Init as usual, but add dashboard_link to object"""
         super().__init__(*args, **kwargs)
@@ -80,7 +81,7 @@ class InfoHandler(RequestHandler):
         cluster = self.application.cluster
         info = {
             "scheduler_address": cluster.scheduler_address,
-            "dashboard_link": cluster.dashboard_link
+            "dashboard_link": cluster.dashboard_link,
         }
         self.write(json.dumps(info))
 
@@ -114,14 +115,16 @@ class AdaptHandler(RequestHandler):
 
 
 def make_app():
-    return SaturnClusterApplication([
-        (r"/", MainHandler),
-        (r"/info", InfoHandler),
-        (r"/scheduler_info", SchedulerInfoHandler),
-        (r"/status", StatusHandler),
-        (r"/scale", ScaleHandler),
-        (r"/adapt", AdaptHandler),
-    ])
+    return SaturnClusterApplication(
+        [
+            (r"/", MainHandler),
+            (r"/info", InfoHandler),
+            (r"/scheduler_info", SchedulerInfoHandler),
+            (r"/status", StatusHandler),
+            (r"/scale", ScaleHandler),
+            (r"/adapt", AdaptHandler),
+        ]
+    )
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -1,24 +1,17 @@
 import os
-import base64
-import uuid
-from os.path import dirname, join, exists, relpath
+from os.path import dirname, join, relpath
 from jinja2 import Environment, FileSystemLoader
 import subprocess
-import base64
-import shutil
 import logging
 
 import click
 import yaml
 from sutils.files import ensure_directory
-from sutils.string import to_bytes, to_string
 
 logger = logging.getLogger(__name__)
 ROOT = dirname(__file__)
-template_path = join(ROOT, 'templates')
-jinja_env = Environment(
-    loader=FileSystemLoader([template_path])
-)
+template_path = join(ROOT, "templates")
+jinja_env = Environment(loader=FileSystemLoader([template_path]))
 jinja_env.trim_blocks = True
 jinja_env.lstrip_blocks = True
 
@@ -33,7 +26,7 @@ def template(data, template_path, dest, suffix):
             _dest = join(dest, rpath)
             ensure_directory(_dest)
             with open(_dest, "w+") as f:
-                print('writing to %s' % _dest)
+                print("writing to %s" % _dest)
                 f.write(jinja_env.get_template(tpath).render(**data))
 
 
@@ -43,9 +36,9 @@ def cli():
 
 
 def rsync(path1, path2, exclude_git=False):
-    if path1.endswith('/'):
+    if path1.endswith("/"):
         path1 = path1[:-1]
-    if path2.endswith('/'):
+    if path2.endswith("/"):
         path2 = path2[:-1]
     if exclude_git:
         cmd = "rsync -av --exclude .git/ %s/ %s"
@@ -56,61 +49,33 @@ def rsync(path1, path2, exclude_git=False):
             path1,
             path2,
         )
-        output = subprocess.check_output(
-            cmd,
-            stderr=subprocess.STDOUT, shell=True
-        )
+        _ = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
     except subprocess.CalledProcessError as e:
         logger.error(e.output)
         raise
 
 
 @cli.command()
-@click.argument('config_path')
-@click.option('--copy', is_flag=True)
+@click.argument("config_path")
+@click.option("--copy", is_flag=True)
 def run(config_path, copy):
     with open(config_path) as f:
         data = yaml.load(f.read(), Loader=yaml.CLoader)
-    out = join(dirname(__file__), 'saturnbase')
-    template(data,
-             template_path,
-             out,
-             'saturnbase'
-    )
-    out = join(dirname(__file__), 'saturnbase-gpu')
-    template(data,
-             template_path,
-             out,
-             'saturnbase'
-    )
-    out = join(dirname(__file__), 'saturnbase-gpu')
-    template(data,
-             template_path,
-             out,
-             'saturnbase-gpu'
-    )
-    out = join(dirname(__file__), 'saturn')
-    template(data,
-             template_path,
-             out,
-             'saturn'
-    )
-    if data['jsaturn_version'] == 'local':
+    out = join(dirname(__file__), "saturnbase")
+    template(data, template_path, out, "saturnbase")
+    out = join(dirname(__file__), "saturnbase-gpu")
+    template(data, template_path, out, "saturnbase")
+    out = join(dirname(__file__), "saturnbase-gpu")
+    template(data, template_path, out, "saturnbase-gpu")
+    out = join(dirname(__file__), "saturn")
+    template(data, template_path, out, "saturn")
+    if data["jsaturn_version"] == "local":
         if copy:
-            rsync("../jupyterlab_saturn", join(out, 'jupyterlab_saturn'),
-                  exclude_git=True)
-    out = join(dirname(__file__), 'saturn-gpu')
-    template(data,
-             template_path,
-             out,
-             'saturn-gpu'
-    )
-    out = join(dirname(__file__), 'scripts')
-    template(data,
-             template_path,
-             out,
-             'scripts'
-    )
+            rsync("../jupyterlab_saturn", join(out, "jupyterlab_saturn"), exclude_git=True)
+    out = join(dirname(__file__), "saturn-gpu")
+    template(data, template_path, out, "saturn-gpu")
+    out = join(dirname(__file__), "scripts")
+    template(data, template_path, out, "scripts")
 
 
 if __name__ == "__main__":

--- a/proxy-server/attic/mock_auth_server/auth_server.py
+++ b/proxy-server/attic/mock_auth_server/auth_server.py
@@ -67,7 +67,7 @@ class HTTPServerHandler(BaseHTTPRequestHandler):
                 "<!DOCTYPE html><html><head><title>Mock Signin</title></head><body>"
                 f"<form action='{html.escape(orig_request[0])}' method='GET'>"
                 f"<input type='hidden' name='saturn_token' value='{html.escape(token)}'/>"
-                "<input type='text' value='my-fake-username'/><br/><input type='password' value='password'/><br/>"   # noqa E501
+                "<input type='text' value='my-fake-username'/><br/><input type='password' value='password'/><br/>"  # noqa E501
                 "<button type='submit'>Sign In</button></form></body></html>".encode("utf-8")
             )
         else:


### PR DESCRIPTION
In reviewing #58 , I just learned that we have more in this repo than shell scripts and Dockerfiles. I did not know about https://github.com/saturncloud/images/blob/main/daskdev-sat/app.py before today :scream: 

This PR proposes adding some Python linting on PRs, to improve our confidence in releases of this project. Today, nothing is automatically preventing a PR that introduces serious issues (even syntax errors) in this project's Python code from being merged. My proposed changes here would do that.

The changes in this diff fix the following issues found by `flake8`:

```text
./main.py:3:1: F401 'uuid' imported but unused
./main.py:4:1: F401 'os.path.exists' imported but unused
./main.py:7:1: F811 redefinition of unused 'base64' from line 2
./main.py:7:1: F401 'base64' imported but unused
./main.py:8:1: F401 'shutil' imported but unused
./main.py:14:1: F401 'sutils.string.to_bytes' imported but unused
./main.py:14:1: F401 'sutils.string.to_string' imported but unused
./main.py:57:9: F841 local variable 'output' is assigned to but never use
```