### PR TITLE
remove unnecessary check in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v1
       - name: Set up Python 3.7
-        if: matrix.task != 'todo-checks'
         uses: s-weigand/setup-conda@v1.0.3
         with:
           python-version: 3.7


### PR DESCRIPTION
realized I left and unnecessary line in the GitHub Actions config when I copied it over from another project, sorry! This PR removes it