### PR TITLE
update saturn image to work with examples in the examples-cpu project

### DIFF
--- a/saturn/environment.yml
+++ b/saturn/environment.yml
@@ -3,6 +3,7 @@ channels:
 - defaults
 - pytorch
 - saturncloud
+- conda-forge
 dependencies:
 - blas=*=mkl
 - bokeh
@@ -18,33 +19,40 @@ dependencies:
 - dask-saturn==0.0.4
 - dask-xgboost
 - dask==2.20.0
+- datashader
 - distributed==2.20.0
 - fastparquet
+- firefox
+- flask
+- geckodriver
 - gensim
 - geopandas
+- geoviews
 - graphviz
 - h5py
+- hvplot
 - ipykernel
 - ipywidgets
-- matplotlib
+- matplotlib==3.2.2
 - nltk
 - numba
 - numpy
-- pandas=1.0.5
+- pandas=1.1.0
+- panel
 - pip
-- pip
+- pip:
+  - snowflake-connector-python==2.3.1
+  - pyarrow==0.17.0
 - prefect
 - pyarrow
 - python=3.7
 - pytorch-cpu
-- s3fs
-- s3fs
+- s3fs==0.4.2
 - scikit-learn
 - scipy
-- snowflake-connector-python
-- snowflake-sqlalchemy
+- selenium
 - tensorflow=2.1.0=mkl_py37h80a91df_0
 - torchvision-cpu
 - voila
 - wordcloud
-- xgboost
+- xgboost==0.90


### PR DESCRIPTION
Major changes:
- add packages for dashboard (`datashader`, `firefox`, `geckodriver`, `geoviews`, `hvplot`, `panel`, `selenium`)
- add `flask` for model serving
- upgrade `pandas`
- pin `s3fs` to 0.4.2 because of some issues with latest release (0.5)
- pin `xgboost` to 0.90 to work with `dask-xgboost`
- install latest `snowflake-connector-python` from pip (latest not on conda), along with compatible `pyarrow`

I believe I have this pointed to the right release branch, let me know if that should change.