### PR TITLE
simplify CI linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v1
       - name: Set up Python 3.7
-        uses: s-weigand/setup-conda@v1.0.3
+        uses: actions/setup-python@v2
         with:
           python-version: 3.7
       - name: linting

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,10 @@
 name: Linting
 
-# run on every push
-on: push
+on:
+  push:
+  schedule:
+    # Run every Monday morning at 11:00a UTC, 6:00a CST
+    - cron: '0 11 * * 1'
 
 jobs:
   test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,17 +1,7 @@
-name: Linting and Unit Tests
+name: Linting
 
-# only run this workflow on new commits to main
-# or PRs into main
-on:
-  push:
-    branches:
-    - main
-  pull_request:
-    branches:
-    - main
-  schedule:
-    # Run every Monday morning at 11:00a UTC, 6:00a CST
-    - cron: '0 11 * * 1'
+# run on every push
+on: push
 
 jobs:
   test:


### PR DESCRIPTION
This PR simplifies the linting action in a few ways:

1. No reason to restrict it to running on main or PRs that target main. Just run it on every push. It's fast.
2. ~No reason to run it on a schedule - the code's not going to change on its own.~
3. Switched from installing `miniconda` to just using `python` instead - we weren't actually using conda.