### PR TITLE
get mypy passing in CI again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,17 @@ format:
 	black --line-length 100 .
 
 .PHONY: lint
-lint:
+lint: flake8 black mypy
+
+.PHONY: flake8
+flake8:
 	flake8 --count --max-line-length 100
+
+.PHONY: black
+black:
 	black --check --diff --line-length 100 .
-	mypy --ignore-missing-imports .
+
+.PHONY: mypy
+mypy:
+	# mypy errors out if passed a directory with no python files in it
+	mypy --ignore-missing-imports daskdev-sat


### PR DESCRIPTION
`mypy` errors out when passed a directory with no python files in it. #78 merged in, which removed `main.py` from the root of this repo - making `mypy` now error out on `main`. To get CI passing again, I modified the makefile to only run `mypy` on `daskdev-sat` - it's the only project left here with python files in it.