### PR TITLE
Install correct version of snowflake-connector-python

### DIFF
--- a/saturn-gpu/environment.yml
+++ b/saturn-gpu/environment.yml
@@ -31,10 +31,10 @@ dependencies:
 - h5py
 - ipykernel
 - ipywidgets
-- llvmlite=0.32.1
+- llvmlite
 - matplotlib
 - nltk
-- numba=0.49.1
+- numba
 - numpy
 - pandas
 - pip
@@ -42,10 +42,11 @@ dependencies:
 - pyarrow
 - python=3.7
 - pytorch=1.4.0=py3.7_cuda10.1.243_cudnn7.6.3_0
-- rapids=0.14.1=cuda10.1_py37_0
+- rapids=0.15.1=cuda10.1_py37_gc1db54b_5
 - s3fs
 - scikit-learn
 - scipy
+- snowflake-connector-python==2.3.2
 - snowflake-sqlalchemy
 - tensorboard=2.1.0
 - tensorflow-base=2.1.0=gpu_py37h6c5654b_0
@@ -55,5 +56,3 @@ dependencies:
 - voila
 - wordcloud
 - xgboost
-- pip:
-  - snowflake-connector-python==2.3.1

--- a/saturn-gpu/environment.yml
+++ b/saturn-gpu/environment.yml
@@ -46,7 +46,6 @@ dependencies:
 - s3fs
 - scikit-learn
 - scipy
-- snowflake-connector-python
 - snowflake-sqlalchemy
 - tensorboard=2.1.0
 - tensorflow-base=2.1.0=gpu_py37h6c5654b_0

--- a/saturn-gpu/environment.yml
+++ b/saturn-gpu/environment.yml
@@ -55,3 +55,5 @@ dependencies:
 - voila
 - wordcloud
 - xgboost
+- pip:
+  - snowflake-connector-python==2.3.1


### PR DESCRIPTION
snowflake-connector-python is pinned at `2.3.1` through pip on the CPU image, this was installing an older version (2.1.1) that does not work on the GPU image.

Context: https://saturn-cloud.slack.com/archives/CQSELL6K1/p1604521555057000

Ran integration-tests on image build from this branch, and all GPU example notebooks passed:
```
tests/test_example_repos/test_examples_gpu.py::TestExamplesGPU::test_rf_sckikit 
[gw0] [ 28%] PASSED tests/test_example_repos/test_examples_gpu.py::TestExamplesGPU::test_rf_sckikit 
tests/test_example_repos/test_examples_gpu.py::TestExamplesGPU::test_rf_rapids 
[gw0] [ 42%] PASSED tests/test_example_repos/test_examples_gpu.py::TestExamplesGPU::test_rf_rapids 
tests/test_example_repos/test_examples_gpu.py::TestExamplesGPU::test_rf_rapids_dask 
[gw0] [ 57%] PASSED tests/test_example_repos/test_examples_gpu.py::TestExamplesGPU::test_rf_rapids_dask 
tests/test_example_repos/test_examples_gpu.py::TestExamplesGPU::test_snowflake_rf_sckikit 
[gw0] [ 71%] PASSED tests/test_example_repos/test_examples_gpu.py::TestExamplesGPU::test_snowflake_rf_sckikit 
tests/test_example_repos/test_examples_gpu.py::TestExamplesGPU::test_snowflake_rf_rapids 
[gw0] [ 85%] PASSED tests/test_example_repos/test_examples_gpu.py::TestExamplesGPU::test_snowflake_rf_rapids 
tests/test_example_repos/test_examples_gpu.py::TestExamplesGPU::test_snowflake_rf_rapids_dask 
[gw0] [100%] PASSED tests/test_example_repos/test_examples_gpu.py::TestExamplesGPU::test_snowflake_rf_rapids_dask 
````