### PR TITLE
use newer prefect-saturn in images

### DIFF
--- a/saturn/environment.yml
+++ b/saturn/environment.yml
@@ -43,4 +43,4 @@ dependencies:
 - pip:
   - snowflake-connector-python==2.3.1
   - pyarrow==0.17.0
-  - prefect-saturn>=0.2.0
+  - prefect-saturn>=0.4.0


### PR DESCRIPTION
`prefect-saturn` 0.3.0 and 0.4.0 introduced breaking changes that improve the user experience with Saturn + Prefect Cloud.

The newer `saturncloud/saturn` images should use at least `prefect-saturn` 0.4.0, so that customers using those images get that better experience without needing to `pip install --upgrade prefect-saturn`.

See [the `prefect-saturn` release notes](https://github.com/saturncloud/prefect-saturn/releases) if you want details on the specific changes in those releases.