### PR TITLE
remove dask-xgboost, use xgboost 1.3.0+

### DIFF
--- a/saturn-gpu/environment.yml
+++ b/saturn-gpu/environment.yml
@@ -21,7 +21,6 @@ dependencies:
 - dash-table
 - dask-ml
 - dask-saturn=0.1.3
-- dask-xgboost
 - dask=2.30.0
 - distributed=2.30.0
 - fastparquet
@@ -55,4 +54,4 @@ dependencies:
 - torchvision=0.5.0=py37_cu101
 - voila
 - wordcloud
-- xgboost
+- xgboost>=1.3.0

--- a/saturn/environment.yml
+++ b/saturn/environment.yml
@@ -10,7 +10,6 @@ dependencies:
 - cvxpy
 - dask-ml
 - dask-saturn==0.1.3
-- dask-xgboost
 - dask==2.30.0
 - datashader
 - distributed==2.30.0
@@ -39,7 +38,7 @@ dependencies:
 - scipy
 - voila
 - wordcloud
-- xgboost==0.90
+- xgboost>=1.3.0
 - pip:
   - snowflake-connector-python==2.3.1
   - pyarrow==0.17.0


### PR DESCRIPTION
This PR accompanies https://github.com/saturncloud/examples/pull/50. It proposes removing `dask-xgboost` the next time we build images, and replacing it with `xgboost>=1.3.0`. The newest release of `xgboost` contains an XGBoost-maintained Dask integration. I've tested that it works on Saturn Dask clusters, so I think we can safely stop recommending `dask-xgboost` and move to `xgboost`.