### PR TITLE
[CU-5wgufp] haproxy

### DIFF
--- a/daskdev-sat/app.py
+++ b/daskdev-sat/app.py
@@ -21,7 +21,6 @@ NAME = os.environ.get("DASK_NAME")
 NAMESPACE = os.environ.get("DASK_NAMESPACE", "main-namespace")
 DASHBOARD_LINK = os.environ.get("DASK_DASHBOARD_LINK", None)
 N_WORKERS = int(os.environ.get("DASK_N_WORKERS", 0))
-TLS_ENABLED = os.environ.get("TLS_ENABLED", "false").lower() == "true"
 WORKER_CONFIG = "/etc/config/worker_spec.yaml"
 SCHEDULER_CONFIG = "/etc/config/scheduler_spec.yaml"
 
@@ -64,8 +63,7 @@ class SaturnKubeCluster(KubeCluster):
         if self._n_workers > 0:
             name = self._generate_name
             namespace = self._namespace
-            protocol = "tls" if TLS_ENABLED else "tcp"
-            scheduler_address = f"{protocol}://{name}.{namespace}:{SCHEDULER_PORT}"
+            scheduler_address = f"tcp://{name}.{namespace}:{SCHEDULER_PORT}"
             self.scheduler = Scheduler(
                 cluster=self,
                 idle_timeout=self._idle_timeout,

--- a/daskdev-sat/app.py
+++ b/daskdev-sat/app.py
@@ -21,6 +21,7 @@ NAME = os.environ.get("DASK_NAME")
 NAMESPACE = os.environ.get("DASK_NAMESPACE", "main-namespace")
 DASHBOARD_LINK = os.environ.get("DASK_DASHBOARD_LINK", None)
 N_WORKERS = int(os.environ.get("DASK_N_WORKERS", 0))
+TLS_ENABLED = os.environ.get("TLS_ENABLED", "false").lower() == "true"
 WORKER_CONFIG = "/etc/config/worker_spec.yaml"
 SCHEDULER_CONFIG = "/etc/config/scheduler_spec.yaml"
 
@@ -63,7 +64,8 @@ class SaturnKubeCluster(KubeCluster):
         if self._n_workers > 0:
             name = self._generate_name
             namespace = self._namespace
-            scheduler_address = f"tcp://{name}.{namespace}:{SCHEDULER_PORT}"
+            protocol = "tls" if TLS_ENABLED else "tcp"
+            scheduler_address = f"{protocol}://{name}.{namespace}:{SCHEDULER_PORT}"
             self.scheduler = Scheduler(
                 cluster=self,
                 idle_timeout=self._idle_timeout,

--- a/proxy-server/go.mod
+++ b/proxy-server/go.mod
@@ -25,6 +25,7 @@ require (
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.0.0-20191004102349-159aefb8556b
 	k8s.io/apimachinery v0.0.0-20191004074956-c5d2f014d689
 	k8s.io/client-go v11.0.1-0.20191029005444-8e4128053008+incompatible

--- a/proxy-server/go.sum
+++ b/proxy-server/go.sum
@@ -105,6 +105,8 @@ k8s.io/api v0.0.0-20191004102349-159aefb8556b h1:mja4wDOEhOlKPQ47X/wU/8SUKoakPfO
 k8s.io/api v0.0.0-20191004102349-159aefb8556b/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apimachinery v0.0.0-20191004074956-c5d2f014d689 h1:q9CWH+mCm21qUeXH537D0Q9K1jdEkreNSRU5E7jh+QM=
 k8s.io/apimachinery v0.0.0-20191004074956-c5d2f014d689/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
+k8s.io/apimachinery v0.19.4 h1:+ZoddM7nbzrDCp0T3SWnyxqf8cbWPT2fkZImoyvHUG0=
+k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
 k8s.io/client-go v11.0.1-0.20191029005444-8e4128053008+incompatible h1:RfzLv39xcqH6QZ+6hgbCsHeH7cXvCA+hwLGHwz8Qg7c=
 k8s.io/client-go v11.0.1-0.20191029005444-8e4128053008+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=

--- a/proxy-server/proxy/config.go
+++ b/proxy-server/proxy/config.go
@@ -1,22 +1,46 @@
 package proxy
 
 import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"log"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"sync"
+	"syscall"
 	"time"
 
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	kubecache "k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/clientcmd"
 )
+
+var configKinds = struct {
+	configMap string
+	secret    string
+}{
+	configMap: "ConfigMap",
+	secret:    "Secret",
+}
+
+var tlsSecretKeys = struct {
+	cert string
+	key  string
+	ca   string
+}{
+	cert: "tls.crt",
+	key:  "tls.key",
+	ca:   "ca.crt",
+}
 
 type ProxyConfig struct {
 	// Map of requested domain prefix to k8s dst address
@@ -116,44 +140,393 @@ func (sc *SessionConfig) Load(configmap interface{}) error {
 	return nil
 }
 
+func NewHAProxyConfig(namespace, clusterDomain, baseDir, pidFile string) *HAProxyConfig {
+	certsDir := filepath.Join(baseDir, "certs")
+	configDir := filepath.Join(baseDir, "config")
+	pending := make(chan bool, 1)
+	os.MkdirAll(configDir, os.ModeDir)
+
+	return &HAProxyConfig{
+		TCPTargetMap:  map[string]TCPTarget{},
+		TLSSecrets:    NewTLSSecrets(certsDir, pending),
+		Namespace:     namespace,
+		ClusterDomain: clusterDomain,
+		BaseDir:       baseDir,
+		ConfigDir:     configDir,
+		PIDFile:       pidFile,
+		Pending:       pending,
+	}
+}
+
+type HAProxyConfig struct {
+	TCPTargetMap  map[string]TCPTarget
+	TLSSecrets    *TLSSecrets
+	Namespace     string
+	ClusterDomain string
+	BaseDir       string
+	ConfigDir     string
+	PIDFile       string
+
+	Pending chan bool
+	mutex   sync.Mutex
+}
+
 /*
-	Create a new watcher for a ConfigMap
+	Load HAProxy configuration from configmap
 */
-func NewConfigWatcher(name, namespace string) *ConfigWatcher {
-	// Load kubeconfig
-	kubeconfigPath := "~/.kube/config"
-	var kubeconfig *rest.Config
-	if _, err := os.Stat(kubeconfigPath); err == nil {
-		kubeconfig, err = clientcmd.BuildConfigFromFlags("", "")
-		if err != nil {
-			log.Panic(err)
-		}
-	} else {
-		kubeconfig, err = rest.InClusterConfig()
-		if err != nil {
-			log.Panic(err)
-		}
-	}
+func (hpc *HAProxyConfig) Load(configmap interface{}) error {
+	hpc.mutex.Lock()
+	defer hpc.mutex.Unlock()
 
-	// Create kube client
-	client, err := kubernetes.NewForConfig(kubeconfig)
+	data, err := loadConfigMap(configmap)
 	if err != nil {
-		log.Panic(err)
+		return err
 	}
 
-	// Create watcher
+	// Load and check for changes
+	tcpTargets := make(map[string]TCPTarget)
+	targetsUpdated := false
+	for hostname, targetYAML := range data {
+		var target TCPTarget
+		err := yaml.Unmarshal([]byte(targetYAML), &target)
+		if err != nil {
+			log.Printf("Error: Failed to load HAProxy config for %s", hostname)
+			continue
+		}
+		if target.Port == 0 || target.ServicePort == 0 || target.ServiceName == "" {
+			log.Printf("Error: Invalid TCP target configuration for %s", hostname)
+			continue
+		}
+		if err := target.setFQDN(hpc.Namespace, hpc.ClusterDomain); err != nil {
+			log.Printf("Error: Failed to configure target FQDN for %s: %s", hostname, err)
+			continue
+		}
+
+		tcpTargets[hostname] = target
+		if existing, ok := hpc.TCPTargetMap[hostname]; ok {
+			targetsUpdated = targetsUpdated || !existing.Compare(target)
+		} else {
+			targetsUpdated = true
+		}
+	}
+	targetsUpdated = targetsUpdated || len(tcpTargets) != len(hpc.TCPTargetMap)
+
+	// Update onchanges
+	if targetsUpdated {
+		hpc.TCPTargetMap = tcpTargets
+		log.Printf("Loaded HAProxy config: %d TCP targets", len(tcpTargets))
+		// Signal for update
+		select {
+		case hpc.Pending <- true:
+		default:
+		}
+	}
+	return nil
+}
+
+func (hpc *HAProxyConfig) Update() error {
+	hpc.mutex.Lock()
+	defer hpc.mutex.Unlock()
+	hpc.TLSSecrets.mutex.Lock()
+	defer hpc.TLSSecrets.mutex.Unlock()
+
+	certListFile := filepath.Join(hpc.ConfigDir, "crt-list.txt")
+	configFile := filepath.Join(hpc.ConfigDir, "haproxy.cfg")
+
+	configData := map[int]map[string]string{}
+	certListData := []map[string]string{}
+	for hostname, target := range hpc.TCPTargetMap {
+		if target.SecretName != "" {
+			tlsConfig, ok := hpc.TLSSecrets.TLSMap[target.SecretName]
+			if !ok {
+				log.Printf("Skipping TCP target %s: Missing TLS secret %s", hostname, target.SecretName)
+				continue
+			} else if err := verifyCert(tlsConfig.Cert, tlsConfig.CA, hostname); err != nil {
+				log.Printf("Skipping TCP target %s: %s", hostname, err.Error())
+				continue
+			}
+
+			// Update certificates
+			if err := tlsConfig.Write(); err != nil {
+				log.Printf(
+					"Error: Failed to write certificate from secret \"%s\" to %s",
+					target.SecretName,
+					hpc.TLSSecrets.CertsDir,
+				)
+				continue
+			}
+
+			// Add to crt-list
+			certListData = append(certListData, map[string]string{
+				"certBundle": tlsConfig.BundleFilepath,
+				"caFile":     tlsConfig.CAFilepath,
+				"hostname":   hostname,
+			})
+		}
+		if _, ok := configData[target.Port]; !ok {
+			configData[target.Port] = map[string]string{}
+		}
+		configData[target.Port][hostname] = fmt.Sprintf("%s:%d", target.ServiceFQDN, target.ServicePort)
+	}
+
+	log.Printf("Writing HAProxy config to %s", configFile)
+	if err := renderTemplate(haproxyConfigTemplate, configFile, configData); err != nil {
+		return fmt.Errorf("Failed to render HAProxy config template: %s", err)
+	}
+	if err := renderTemplate(haproxyCertListTemplate, certListFile, certListData); err != nil {
+		return fmt.Errorf("Failed to render HAProxy cert list template: %s", err)
+	}
+
+	if err := hpc.reload(); err != nil {
+		return fmt.Errorf("Failed to reload HAProxy: %s", err)
+	}
+	return nil
+}
+
+func (hpc *HAProxyConfig) Clear() {
+	hpc.mutex.Lock()
+	defer hpc.mutex.Unlock()
+
+	hpc.TCPTargetMap = map[string]TCPTarget{}
+	log.Println("Removed HAProxy configuration")
+
+	// Signal for update
+	select {
+	case hpc.Pending <- true:
+	default:
+	}
+}
+
+func (hpc *HAProxyConfig) getPID() (int, error) {
+	f, err := os.Open(hpc.PIDFile)
+	if err != nil {
+		return -1, err
+	}
+	defer f.Close()
+
+	var pid int
+	_, err = fmt.Fscan(f, &pid)
+	return pid, err
+}
+
+/*
+	Retrieve the PID of HAProxy and signal to reload its configuration
+*/
+func (hpc *HAProxyConfig) reload() error {
+	pid, err := hpc.getPID()
+	if err != nil {
+		return err
+	}
+
+	return syscall.Kill(pid, syscall.SIGUSR2)
+}
+
+type TCPTarget struct {
+	Port        int    `yaml:"port"`
+	ServiceName string `yaml:"serviceName"`
+	ServicePort int    `yaml:"servicePort"`
+	SecretName  string `yaml:"secretName"`
+
+	// Required by HAProxy DNS resolver
+	ServiceFQDN string
+}
+
+/*
+	Return true if the targets match
+*/
+func (tt *TCPTarget) Compare(target TCPTarget) bool {
+	return tt.Port == target.Port &&
+		tt.ServiceName == target.ServiceName &&
+		tt.ServicePort == target.ServicePort &&
+		tt.SecretName == target.SecretName
+}
+
+func (tt *TCPTarget) setFQDN(namespace, clusterDomain string) error {
+	switch len(strings.Split(tt.ServiceName, ".")) {
+	case 1:
+		tt.ServiceFQDN = fmt.Sprintf("%s.%s.svc.%s", tt.ServiceName, namespace, clusterDomain)
+	case 2:
+		tt.ServiceFQDN = fmt.Sprintf("%s.svc.%s", tt.ServiceName, clusterDomain)
+	default:
+		if !strings.HasSuffix(tt.ServiceName, fmt.Sprintf(".svc.%s", clusterDomain)) {
+			return fmt.Errorf("Invalid service name \"%s\"", tt.ServiceName)
+		}
+	}
+	return nil
+}
+
+func NewTLSSecrets(certsDir string, pending chan bool) *TLSSecrets {
+	os.MkdirAll(certsDir, 0600)
+	return &TLSSecrets{
+		TLSMap:   map[string]*TLSConfig{},
+		CertsDir: certsDir,
+		pending:  pending,
+	}
+}
+
+type TLSSecrets struct {
+	TLSMap   map[string]*TLSConfig
+	CertsDir string
+	pending  chan bool
+	mutex    sync.Mutex
+}
+
+/*
+	Load TLS certificates from Secret
+*/
+func (ts *TLSSecrets) Load(secretObj interface{}) error {
+	ts.mutex.Lock()
+	defer ts.mutex.Unlock()
+
+	secret, err := loadSecret(secretObj)
+	if err != nil {
+		log.Printf("Error: Failed to load secret: %s", err)
+		return err
+	}
+	secretName := secret.ObjectMeta.Name
+
+	// Load and check for changes
+	tlsConfig := &TLSConfig{
+		Cert:           secret.Data[tlsSecretKeys.cert],
+		Key:            secret.Data[tlsSecretKeys.key],
+		CA:             secret.Data[tlsSecretKeys.ca],
+		BundleFilepath: fmt.Sprintf("%s/%s-bundle.pem", ts.CertsDir, secretName),
+		CAFilepath:     fmt.Sprintf("%s/%s-ca.pem", ts.CertsDir, secretName),
+	}
+
+	if existing, ok := ts.TLSMap[secretName]; !ok || !existing.Compare(tlsConfig) {
+		ts.TLSMap[secretName] = tlsConfig
+		log.Printf("Loaded HAProxy certificate: %s", secretName)
+
+		// Signal for update
+		select {
+		case ts.pending <- true:
+		default:
+		}
+	}
+
+	return nil
+}
+
+/*
+	Remove secret from TLS configuration, and delete associated cert files
+*/
+func (ts *TLSSecrets) Delete(secretObj interface{}) error {
+	ts.mutex.Lock()
+	defer ts.mutex.Unlock()
+
+	secret, err := loadSecret(secretObj)
+	if err != nil {
+		log.Printf("Error: Failed to load secret: %s", err)
+		return err
+	}
+	secretName := secret.ObjectMeta.Name
+
+	if tlsConfig, ok := ts.TLSMap[secretName]; ok {
+		delete(ts.TLSMap, secretName)
+
+		// Removing the cert files is not the most critical part of deleting the TLS configuration,
+		// so just logging the error is fine. Removing the TLSConfig from the map will remove it from
+		// the crt-list.txt on next update, so the certificates will not be in use.
+		if err := os.Remove(tlsConfig.BundleFilepath); err != nil {
+			if !os.IsNotExist(err) {
+				log.Printf("Error: Failed to delete %s certificate bundle: %s", secretName, err)
+			}
+		}
+		if err := os.Remove(tlsConfig.CAFilepath); err != nil {
+			if !os.IsNotExist(err) {
+				log.Printf("Error: Failed to delete %s CA: %s", secretName, err)
+			}
+		}
+
+		log.Printf("Removed TLS config for %s", secretName)
+
+		// Signal for update
+		select {
+		case ts.pending <- true:
+		default:
+		}
+	}
+
+	return nil
+}
+
+type TLSConfig struct {
+	Cert []byte
+	Key  []byte
+	CA   []byte
+
+	BundleFilepath string
+	CAFilepath     string
+}
+
+/*
+	Return true if the TLSConfigs match
+*/
+func (tc *TLSConfig) Compare(config *TLSConfig) bool {
+	if diff := bytes.Compare(tc.Cert, config.Cert); diff != 0 {
+		return false
+	}
+	if diff := bytes.Compare(tc.Key, config.Key); diff != 0 {
+		return false
+	}
+	if diff := bytes.Compare(tc.CA, config.CA); diff != 0 {
+		return false
+	}
+	return true
+}
+
+func (tc *TLSConfig) Write() error {
+	f, err := os.OpenFile(tc.BundleFilepath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.Write(tc.Cert); err != nil {
+		return err
+	}
+	if !bytes.HasSuffix(tc.Cert, []byte("\n")) {
+		if _, err := f.WriteString("\n"); err != nil {
+			return err
+		}
+	}
+	if _, err := f.Write(tc.Key); err != nil {
+		return err
+	}
+
+	f2, err := os.OpenFile(tc.CAFilepath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f2.Close()
+
+	if _, err := f2.Write(tc.CA); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+/*
+	Create a new watcher for ConfigMaps or Secrets
+*/
+func NewConfigWatcher(kind, namespace string, client *kubernetes.Clientset) *ConfigWatcher {
+	if kind != configKinds.configMap && kind != configKinds.secret {
+		log.Panicf("Invalid config kind \"%s\"", kind)
+	}
 	return &ConfigWatcher{
-		Name:      name,
+		Kind:      kind,
 		Namespace: namespace,
 		client:    client,
 	}
 }
 
 /*
-	Watches for changes to a given ConfigMap
+	Watches for changes to ConfigMaps or Secrets
 */
 type ConfigWatcher struct {
-	Name      string
+	Kind      string
 	Namespace string
 	client    *kubernetes.Clientset
 }
@@ -162,7 +535,7 @@ type ConfigWatcher struct {
 	Watch for updates to proxy configmaps, using the given event handlers to process the data.
 	This will block execution, so it should be run on its own goroutine.
 */
-func (cw *ConfigWatcher) Watch(eventHandler kubecache.ResourceEventHandlerFuncs) {
+func (cw *ConfigWatcher) Watch(eventHandler kubecache.ResourceEventHandlerFuncs, listOptions func(options *metav1.ListOptions)) {
 
 	// Resync period, triggers UpdateFunc even when no change events were found
 	defaultResync := time.Second * 30
@@ -170,11 +543,14 @@ func (cw *ConfigWatcher) Watch(eventHandler kubecache.ResourceEventHandlerFuncs)
 	// Create configmap informer with name/namespace filter
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(
 		cw.client, defaultResync, kubeinformers.WithNamespace(cw.Namespace),
-		kubeinformers.WithTweakListOptions(func(options *metav1.ListOptions) {
-			options.FieldSelector = fmt.Sprintf("metadata.name=%s", cw.Name)
-		}),
+		kubeinformers.WithTweakListOptions(listOptions),
 	)
-	cfgInformer := kubeInformerFactory.Core().V1().ConfigMaps().Informer()
+	var cfgInformer cache.SharedIndexInformer
+	if cw.Kind == configKinds.configMap {
+		cfgInformer = kubeInformerFactory.Core().V1().ConfigMaps().Informer()
+	} else {
+		cfgInformer = kubeInformerFactory.Core().V1().Secrets().Informer()
+	}
 
 	// Add handler functions for add/update/delete
 	cfgInformer.AddEventHandler(eventHandler)
@@ -193,10 +569,53 @@ func (cw *ConfigWatcher) Watch(eventHandler kubecache.ResourceEventHandlerFuncs)
 /*
 	Load the data from a configmap obj interface (as passed in by ResourceEventHandlerFuncs)
 */
-func loadConfigMap(configmap interface{}) (map[string]string, error) {
-	cfg, ok := configmap.(*corev1.ConfigMap)
+func loadConfigMap(configmapObj interface{}) (map[string]string, error) {
+	configmap, ok := configmapObj.(*corev1.ConfigMap)
 	if !ok {
 		return nil, errors.New("Watcher returned non-configmap object")
 	}
-	return cfg.Data, nil
+	return configmap.Data, nil
+}
+
+/*
+	Load a secret from an interface (as passed in by ResourceEventHandlerFuncs)
+*/
+func loadSecret(secretObj interface{}) (*corev1.Secret, error) {
+	secret, ok := secretObj.(*corev1.Secret)
+	if !ok {
+		return nil, errors.New("Watcher returned non-secret object")
+	}
+	return secret, nil
+}
+
+/*
+	Validate a certificate for a given CA and hostname
+*/
+func verifyCert(certPEM, caCertPEM []byte, hostname string) error {
+	roots := x509.NewCertPool()
+	ok := roots.AppendCertsFromPEM([]byte(caCertPEM))
+	if !ok {
+		return fmt.Errorf("Failed to parse CA certificate")
+	}
+
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil {
+		return fmt.Errorf("Failed to decode server certificate")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("Failed to parse server certificate: %s", err.Error())
+	}
+
+	opts := x509.VerifyOptions{
+		DNSName:   hostname,
+		Roots:     roots,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+
+	if _, err := cert.Verify(opts); err != nil {
+		return fmt.Errorf("Failed to verify certificate: %s", err.Error())
+	}
+
+	return nil
 }

--- a/proxy-server/proxy/server.go
+++ b/proxy-server/proxy/server.go
@@ -581,7 +581,7 @@ func Run() {
 	haproxyEnabled, err = strconv.ParseBool(getEnv("HAPROXY_ENABLED", "false"))
 	haproxyDir = getEnv("HAPROXY_CONFIG_DIR", haproxyDir)
 	haproxyPIDFile = getEnv("HAPROXY_PID_FILE", filepath.Join(haproxyDir, "haproxy.pid"))
-	haproxyReloadRateLimit, err = time.ParseDuration(getEnv("HAPROXY_RELOAD_RATE_LIMIT", "5s"))
+	haproxyReloadRateLimit, err = time.ParseDuration(getEnv("HAPROXY_RELOAD_RATE_LIMIT", "3s"))
 	if err != nil {
 		log.Panicf("Error: Invalid HAPROXY_RELOAD_RATE_LIMIT: %s", err)
 	}

--- a/proxy-server/proxy/template.go
+++ b/proxy-server/proxy/template.go
@@ -7,24 +7,32 @@ import (
 
 var haproxyConfigTemplate = `
 {{- range $port, $targets := . }}
-frontend dask-scheduler
-	bind 0.0.0.0:{{ $port }} ssl strict-sni crt-list /etc/haproxy/config/crt-list.txt
+frontend tcp-{{ $port }}
+	mode tcp
+	bind 0.0.0.0:{{ $port }}
 
-	{{- range $hostname, $service := $targets }}
-	acl {{ $hostname }} ssl_fc_sni -i {{ $hostname }}
-	use_backend {{ $hostname }} if {{ $hostname }}
+	# Wait up to 5s from the time the TCP socket opens for an SSL handshake
+	tcp-request inspect-delay 5s
+	tcp-request content accept if { req_ssl_hello_type 1 }
+
+	# Filter connections by SNI. Invalid hostnames will be rejected.
+	{{- range $target := $targets }}
+	use_backend loopback-{{ $target.hostname }} if { req_ssl_sni -i {{ $target.hostname }} }
 	{{ end }}
-
-{{- range $hostname, $service := $targets }}
-backend {{ $hostname }}
-	server scheduler {{ $service }} resolvers dns
 {{ end }}
-{{ end }}
-`
 
-var haproxyCertListTemplate = `
-{{- range $entry := . }}
-{{ $entry.certBundle }} [ca-file {{ $entry.caFile }} verify required] {{ $entry.hostname }}
+{{- range $port, $targets := . }}
+{{- range $target := $targets }}
+#----------- {{ $target.hostname }} proxy -----------
+backend loopback-{{ $target.hostname }}
+	# Loopback to TLS listener on abstract namespace
+	server loopback-for-tls abns@{{ $target.hostname }} send-proxy-v2
+
+listen {{ $target.hostname }}
+	# Internal bind with TLS configuration for the hostname
+	bind abns@{{ $target.hostname }} accept-proxy ssl crt {{ $target.certBundle }} ca-file {{ $target.caFile}} strict-sni
+	server {{ $target.serviceName }} {{ $target.serviceAddress }} resolvers dns
+{{ end }}
 {{ end }}
 `
 

--- a/proxy-server/proxy/template.go
+++ b/proxy-server/proxy/template.go
@@ -1,0 +1,47 @@
+package proxy
+
+import (
+	"os"
+	"text/template"
+)
+
+var haproxyConfigTemplate = `
+{{- range $port, $targets := . }}
+frontend dask-scheduler
+	bind 0.0.0.0:{{ $port }} ssl strict-sni crt-list /etc/haproxy/config/crt-list.txt
+
+	{{- range $hostname, $service := $targets }}
+	acl {{ $hostname }} ssl_fc_sni -i {{ $hostname }}
+	use_backend {{ $hostname }} if {{ $hostname }}
+	{{ end }}
+
+{{- range $hostname, $service := $targets }}
+backend {{ $hostname }}
+	server scheduler {{ $service }} resolvers dns
+{{ end }}
+{{ end }}
+`
+
+var haproxyCertListTemplate = `
+{{- range $entry := . }}
+{{ $entry.certBundle }} [ca-file {{ $entry.caFile }} verify required] {{ $entry.hostname }}
+{{ end }}
+`
+
+/*
+	Renders a template with the given input data
+*/
+func renderTemplate(templateString, outFile string, data interface{}) error {
+	tmpl, err := template.New("tmpl").Parse(templateString)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(outFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return tmpl.Execute(f, data)
+}


### PR DESCRIPTION
- Update ConfigWatcher to allow it to watch for secrets and configmaps with any listOptions filter (label selector, filter selector, etc.)
- Add watcher for HAProxy TCP configmap
- Add watcher for TLS certificate secrets
- Structs for parsing and generating HAProxy config files, loading/validating X509 certificates, and writing files to disk
- Watch for update signals to trigger HAProxy soft reload