### PR TITLE
[DEV-1227] Replace pyyaml

### DIFF
--- a/daskdev-sat/Dockerfile
+++ b/daskdev-sat/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get -qq update && \
     rm -rf /var/lib/apt/lists/*
 ENV SHELL /bin/bash
 
-RUN conda install -y -c conda-forge tornado kubernetes dask-kubernetes=0.11.0 python-kubernetes && \
+RUN conda install -y -c conda-forge tornado kubernetes dask-kubernetes=0.11.0 python-kubernetes ruamel.yaml && \
     conda clean --yes --all
 
 #TODO - remove this pdc crap

--- a/daskdev-sat/app.py
+++ b/daskdev-sat/app.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import yaml
 import asyncio
 import kubernetes
 
@@ -11,6 +10,7 @@ from tornado.web import RequestHandler, Application
 from distributed.core import rpc as dask_rpc
 from dask_kubernetes import KubeCluster, make_pod_from_dict
 from dask_kubernetes.core import Scheduler, SCHEDULER_PORT
+from ruamel import yaml
 
 
 logging.basicConfig(level=logging.INFO)
@@ -27,10 +27,10 @@ SCHEDULER_CONFIG = "/etc/config/scheduler_spec.yaml"
 
 def make_cluster(n_workers):
     with open(WORKER_CONFIG) as f:
-        d = yaml.safe_load(f)
+        d = yaml.load(f.read(), Loader=yaml.SafeLoader)
         pod_template = make_pod_from_dict(d)
     with open(SCHEDULER_CONFIG) as f:
-        d = yaml.safe_load(f)
+        d = yaml.load(f.read(), Loader=yaml.SafeLoader)
         scheduler_pod_template = make_pod_from_dict(d)
 
     log.info(f"Starting dask cluster {NAME} in namespace {NAMESPACE}")


### PR DESCRIPTION
Unlike PyYAML, ruamel.yaml supports:
    * YAML <= 1.2. PyYAML only supports YAML <= 1.1
    This is vital, as YAML 1.2 intentionally breaks backward compatibility
    with YAML 1.1 in several edge cases. This would usually be a bad thing.
    In this case, this renders YAML 1.2 a strict superset of JSON. Since
    YAML 1.1 is not a strict superset of JSON, this is a good thing.
    * Roundtrip preservation
    When calling yaml.dump() to dump a dictionary loaded by a prior call
    to yaml.load():

See more details at https://yaml.readthedocs.io/en/latest/pyyaml.html
