### PR TITLE
[DEV-1245] add a Saturn-y display name on saturn jupyter kernel

### DIFF
--- a/saturn-gpu/Dockerfile
+++ b/saturn-gpu/Dockerfile
@@ -3,7 +3,10 @@ FROM ${SATURNBASE_GPU_IMAGE}
 
 COPY environment.yml /tmp/environment.yml
 RUN conda env update -n saturn --file /tmp/environment.yml && \
-    ${CONDA_DIR}/envs/saturn/bin/python -m ipykernel install --name python3 --prefix=${CONDA_DIR} && \
+    ${CONDA_DIR}/envs/saturn/bin/python -m ipykernel install \
+        --name python3 \
+        --display-name 'saturn (Python 3)' \
+        --prefix=${CONDA_DIR} && \
     ${CONDA_DIR}/bin/conda clean -afy && \
     find ${CONDA_DIR} -type f,l -name '*.pyc' -delete && \
     find ${CONDA_DIR} -type f,l -name '*.a' -delete && \

--- a/saturn/Dockerfile
+++ b/saturn/Dockerfile
@@ -3,7 +3,10 @@ FROM ${SATURNBASE_IMAGE}
 
 COPY environment.yml /tmp/environment.yml
 RUN conda env update -n saturn --file /tmp/environment.yml && \
-    ${CONDA_DIR}/envs/saturn/bin/python -m ipykernel install --name python3 --prefix=${CONDA_DIR} && \
+    ${CONDA_DIR}/envs/saturn/bin/python -m ipykernel install \
+        --name python3 \
+        --display-name 'saturn (Python 3)' \
+        --prefix=${CONDA_DIR} && \
     ${CONDA_DIR}/bin/conda clean -afy && \
     find ${CONDA_DIR} -type f,l -name '*.pyc' -delete && \
     find ${CONDA_DIR} -type f,l -name '*.a' -delete && \


### PR DESCRIPTION
`saturn` images come with a default conda environment called `saturn`. Those images also contain a Jupyter notebook kernel built from that conda environment.

Today in Saturn, that environment's display name is "Python 3". Based on support work I've done with customers, I think this can be confusing. This PR proposes adding a saturn-y display name so that it's a little bit more obvious that you're in a Saturn-created kernel.

![kernel-name-circled](https://user-images.githubusercontent.com/7608904/103823134-17f09c00-5037-11eb-9deb-c61ba10e1d73.png)



### How to test this

1. Replace `saturn/environment.yml` with this smaller env (for speed):

```yaml
name: saturn
channels:
- defaults
- pytorch
- saturncloud
- conda-forge
dependencies:
- ipykernel
- ipywidgets
- pip
- pip:
  - prefect-saturn>=0.4.0
  - dask-saturn==0.2.0
```

2. Run a container registry locally in k8s, following the instructions at https://github.com/saturncloud/saturn#working-with-local-registry.

3. Build an image and push it to that local registry.

```shell
cd saturn
IMAGE_TAG=localhost:32000/saturncloud/saturn-kernel-test:dev
docker build \
    --build-arg SATURNBASE_IMAGE=saturncloud/saturnbase:2020.12.11 \
    -t ${IMAGE_TAG} \
    .

docker push ${IMAGE_TAG}
```

4. In `saturn/.env_deps`, change `SATURN_IMAGE`

```shell
SATURN_IMAGE=localhost:32000/saturncloud/saturn-kernel-test:dev
```

5. start up saturn

```shell
make clean
make aws-creds run
```

6. Edit the `examples-cpu` Jupyter to use image localhost:32000/saturncloud/saturn-kernel-test:dev. Start it. Go into Jupyter Lab.

7. Open any notebook. In the top right corner, you should see `saturn (Python 3)`.

8. Click on that to change the kernel. In the dropdown that pops up, you should see `saturn (Python 3)`.
