### PR TITLE
Add symlink for /opt/conda

### DIFF
--- a/saturnbase-gpu/Dockerfile
+++ b/saturnbase-gpu/Dockerfile
@@ -5,7 +5,9 @@ ARG JUPYTER_SATURN_VERSION
 
 ENV JUPYTER_SATURN_VERSION=${JUPYTER_SATURN_VERSION}
 
-RUN ln -s /opt/conda /srv/conda && chown 1000:1000 -R /opt/conda
+RUN mkdir /opt/conda && \
+    ln -s /opt/conda /srv/conda && \
+    chown 1000:1000 -R /opt/conda
 ENV APP_BASE=/srv
 ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin

--- a/saturnbase-gpu/Dockerfile
+++ b/saturnbase-gpu/Dockerfile
@@ -5,6 +5,7 @@ ARG JUPYTER_SATURN_VERSION
 
 ENV JUPYTER_SATURN_VERSION=${JUPYTER_SATURN_VERSION}
 
+RUN ln -s /opt/conda /srv/conda && chown 1000:1000 -R /opt/conda
 ENV APP_BASE=/srv
 ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin

--- a/saturnbase-gpu/install-miniconda.bash
+++ b/saturnbase-gpu/install-miniconda.bash
@@ -17,7 +17,8 @@ if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
     exit 1
 fi
 
-bash ${INSTALLER_PATH} -b -p ${CONDA_DIR}
+bash ${INSTALLER_PATH} -b -p ${CONDA_DIR} -f
+
 export PATH="${CONDA_BIN}:$PATH"
 
 # Allow easy direct installs from conda forge

--- a/saturnbase/Dockerfile
+++ b/saturnbase/Dockerfile
@@ -5,11 +5,10 @@ ARG JUPYTER_SATURN_VERSION
 
 ENV JUPYTER_SATURN_VERSION=${JUPYTER_SATURN_VERSION}
 
-RUN ln -s /opt/conda /srv/conda
-RUN chown 1000:1000 -R /opt/conda
+RUN ln -s /opt/conda /srv/conda && chown 1000:1000 -R /opt/conda
 ENV APP_BASE=/srv
 ENV CONDA_DIR=/srv/conda
-ENV CONDA_BIN=/srv/conda/bin
+ENV CONDA_BIN=${CONDA_DIR}/bin
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -qq update && \
     apt-get -qq install --yes --no-install-recommends \


### PR DESCRIPTION
Add symlink in GPU base image from /opt/conda to /srv/conda, since the PATH only references the /opt/conda/... path now. 

Cleanup CPU base image to match