### PR TITLE
Update distributed to make sure that comms timeout works

### DIFF
--- a/daskdev-sat/Dockerfile
+++ b/daskdev-sat/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get -qq update && \
 ENV SHELL /bin/bash
 
 RUN conda install -y -c conda-forge tornado kubernetes dask-kubernetes=0.11.0 python-kubernetes ruamel.yaml && \
-    conda clean --yes --all
+    conda clean --yes --all && \
+    pip install distributed==2.30.1 --no-deps
 
 #TODO - remove this pdc crap
 #TODO - run as non-root user

--- a/saturn-gpu/environment.yml
+++ b/saturn-gpu/environment.yml
@@ -21,7 +21,7 @@ dependencies:
 - dash-table
 - dask-ml
 - dask=2.30.0
-- distributed=2.30.0
+- distributed=2.30.1
 - fastparquet
 - gensim
 - geopandas

--- a/saturn/environment.yml
+++ b/saturn/environment.yml
@@ -11,7 +11,7 @@ dependencies:
 - dask-ml
 - dask==2.30.0
 - datashader
-- distributed==2.30.0
+- distributed==2.30.1
 - fastparquet
 - flask
 - gensim


### PR DESCRIPTION
The dask cluster widget was showing no workers because the kubecluster pod was not successfully establishing a connection with the scheduler pod. 