### PR TITLE
Add jupyterlab-python-file extension, copy changes to saturnbase-gpu

### DIFF
--- a/saturnbase-gpu/environment.yml
+++ b/saturnbase-gpu/environment.yml
@@ -7,10 +7,16 @@ dependencies:
   - nodejs=11
   - python=3.7
   - ipywidgets
-  - jupyterlab=2.0.1
+  - jupyterlab=2.2.0
   - nbconvert
   - notebook
   - jupyter-server-proxy
+  - dask-labextension=3.0.0
+  - yarl=1.4.2
+  - pyviz_comms
+  - jupyterlab_code_formatter=1.3.8
+  - black
+  - isort
   - tornado=6
   - jupyter_saturn=${JUPYTER_SATURN_VERSION}
   - nbdime

--- a/saturnbase-gpu/install-jupyter.bash
+++ b/saturnbase-gpu/install-jupyter.bash
@@ -8,11 +8,19 @@ cd $(dirname $0)
 echo "installing root env:"
 cat /tmp/environment.yml
 conda env update -n root  -f /tmp/environment.yml
-jupyter serverextension enable jupyter_server_proxy --sys-prefix
+jupyter serverextension enable --sys-prefix jupyter_server_proxy
 jupyter serverextension enable --py jsaturn --sys-prefix
+jupyter serverextension enable dask_labextension --sys-prefix
+jupyter serverextension enable --py jupyterlab_code_formatter --sys-prefix
 
 jupyter labextension install @bokeh/jupyter_bokeh
 jupyter labextension install @jupyter-widgets/jupyterlab-manager
+jupyter labextension install dask-labextension@3.0.0
+jupyter labextension install @ryantam626/jupyterlab_code_formatter@1.3.8
+jupyter labextension install @pyviz/jupyterlab_pyviz
+jupyter labextension install jupyterlab-execute-time
+jupyter labextension install @telamonian/theme-darcula
+jupyter labextension install jupyterlab-python-file
 
 cd ${CONDA_DIR}/jsaturn_ext
 npm install
@@ -26,9 +34,9 @@ conda clean -afy
 jupyter lab clean
 jlpm cache clean
 npm cache clean --force
-find ${CONDA_DIR} -type f,l -name '*.pyc' -delete
-find ${CONDA_DIR} -type f,l -name '*.a' -delete
-find ${CONDA_DIR} -type f,l -name '*.js.map' -delete
+find ${CONDA_DIR}/ -type f,l -name '*.pyc' -delete
+find ${CONDA_DIR}/ -type f,l -name '*.a' -delete
+find ${CONDA_DIR}/ -type f,l -name '*.js.map' -delete
 rm -rf $HOME/.node-gyp
 rm -rf $HOME/.local
 

--- a/saturnbase/install-jupyter.bash
+++ b/saturnbase/install-jupyter.bash
@@ -20,6 +20,7 @@ jupyter labextension install @ryantam626/jupyterlab_code_formatter@1.3.8
 jupyter labextension install @pyviz/jupyterlab_pyviz
 jupyter labextension install jupyterlab-execute-time
 jupyter labextension install @telamonian/theme-darcula
+jupyter labextension install jupyterlab-python-file
 
 cd ${CONDA_DIR}/jsaturn_ext
 npm install


### PR DESCRIPTION
- Added jupyterlab-python-file
- Copied saturnbase config to saturnbase-gpu (some changes on install-jupyter.bash are no-op, but copied the full file so it is identical with saturnbase)