### PR TITLE
[DEV-1623] Open default ports without targets

### DIFF
--- a/proxy-server/local.sh
+++ b/proxy-server/local.sh
@@ -7,16 +7,13 @@ usage() {
         Commands:
             build: Build image, push to local registry, and set image on saturn-auth-proxy deployment(s)
         Options:
-            -n, --namespace: Namespace(s) to update (default: "main-namespace"
-            --tail: Tail logs after deploying new image. If multiple namepsaces are specified by namespace param (e.g. default),
+            -n, --namespace: Namespace(s) to update (default: "main-namespace")
+            --tail: Tail logs after deploying new image. If multiple namepsaces are specified by namespace param,
                     you may pass a single namespace to tail with this param.
 
     Examples:
-        # Set new image only in main, and tail logs
+        # Set new image in main-namespace, and tail logs
         ./local.sh build -n main-namespace --tail
-
-        # Set new image in both namesapces, and tail the proxy in main
-        ./local.sh build --tail main-namespace
 '
 }
 

--- a/proxy-server/proxy/server.go
+++ b/proxy-server/proxy/server.go
@@ -464,6 +464,7 @@ func Run(settingsFile string) {
 			settings.ClusterDomain,
 			settings.HAProxy.BaseDir,
 			settings.HAProxy.PIDFile,
+			settings.HAProxy.DefaultListeners,
 		)
 		haproxyConfig.Watch(
 			settings.ProxyConfigMaps.TCPTargets,

--- a/proxy-server/util/settings.go
+++ b/proxy-server/util/settings.go
@@ -22,6 +22,7 @@ func LoadSettings(settingsFile string) (*Settings, error) {
 		PIDFile:            "/etc/haproxy/haproxy.pid",
 		ReloadRateLimitStr: "3s",
 		TLSLabelSelector:   "saturncloud.io/certificate=server",
+		DefaultListeners:   []int{},
 	}
 	proxyConfigMaps := &ProxyConfigMaps{
 		HTTPTargets:  "saturn-auth-proxy",
@@ -208,6 +209,7 @@ type HAProxy struct {
 	PIDFile            string `yaml:"pidFile"`
 	ReloadRateLimitStr string `yaml:"reloadRateLimit"`
 	TLSLabelSelector   string `yaml:"tlsLabelSelector"`
+	DefaultListeners   []int  `yaml:"defaultListeners"`
 
 	ReloadRateLimit time.Duration
 }


### PR DESCRIPTION
Add setting to open ports in HAProxy by default, even when no TCP targets are configured. This will allow nginx to successfully make a connection to its configured backend, and HAProxy will respond with an empty reply when there are no dask-schedulers exposed.

```
bhperry@system76-pc:~/workspace/images/proxy-server$ curl http://10.1.43.53:8786
curl: (52) Empty reply from server
bhperry@system76-pc:~/workspace/images/proxy-server$ nc -zv 10.1.43.53 8786
Connection to 10.1.43.53 8786 port [tcp/*] succeeded!
```