### PR TITLE
remove unused config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,0 @@
-build_type: prod
-jsaturn_version: 1.2.7
-base_image_version: 0.9.3.7
-image_version: 0.9.3.7


### PR DESCRIPTION
`config.yaml` at the root of this repo seems like it's unused, and I think it can safely be removed. It isn't referenced by any code here or in other deployment repos.