### PR TITLE
ignore cache when building images

### DIFF
--- a/examples-cpu/Makefile
+++ b/examples-cpu/Makefile
@@ -2,4 +2,8 @@ include .env_deps
 export
 
 build_image:
-	docker build --build-arg SATURNBASE_IMAGE=${SATURNBASE_IMAGE} -t ${IMAGE} .
+	docker build \
+		--no-cache \
+		--build-arg SATURNBASE_IMAGE=${SATURNBASE_IMAGE} \
+		-t ${IMAGE} \
+		.

--- a/examples-gpu/Makefile
+++ b/examples-gpu/Makefile
@@ -2,4 +2,8 @@ include .env_deps
 export
 
 build_image:
-	docker build --build-arg SATURNBASE_GPU_IMAGE=${SATURNBASE_GPU_IMAGE} -t ${IMAGE} .
+	docker build \
+		--no-cache \
+		--build-arg SATURNBASE_GPU_IMAGE=${SATURNBASE_GPU_IMAGE} \
+		-t ${IMAGE} \
+		.

--- a/saturn-geospatial/Makefile
+++ b/saturn-geospatial/Makefile
@@ -2,4 +2,8 @@ include .env_deps
 export
 
 build_image:
-	docker build --build-arg SATURNBASE_IMAGE=${SATURNBASE_IMAGE} -t ${IMAGE} .
+	docker build \
+		--no-cache \
+		--build-arg SATURNBASE_IMAGE=${SATURNBASE_IMAGE} \
+		-t ${IMAGE} \
+		.

--- a/saturn-pytorch/Makefile
+++ b/saturn-pytorch/Makefile
@@ -2,4 +2,8 @@ include .env_deps
 export
 
 build_image:
-	docker build --build-arg SATURNBASE_GPU_IMAGE=${SATURNBASE_GPU_IMAGE} -t ${IMAGE} .
+	docker build \
+		--no-cache \
+		--build-arg SATURNBASE_GPU_IMAGE=${SATURNBASE_GPU_IMAGE} \
+		-t ${IMAGE} \
+		.

--- a/saturn-rapids/Makefile
+++ b/saturn-rapids/Makefile
@@ -2,4 +2,8 @@ include .env_deps
 export
 
 build_image:
-	docker build --build-arg SATURNBASE_GPU_IMAGE=${SATURNBASE_GPU_IMAGE} -t ${IMAGE} .
+	docker build \
+		--no-cache \
+		--build-arg SATURNBASE_GPU_IMAGE=${SATURNBASE_GPU_IMAGE} \
+		-t ${IMAGE} \
+		.

--- a/saturn-tensorflow/Makefile
+++ b/saturn-tensorflow/Makefile
@@ -2,4 +2,8 @@ include .env_deps
 export
 
 build_image:
-	docker build --build-arg SATURNBASE_GPU_IMAGE=${SATURNBASE_GPU_IMAGE} -t ${IMAGE} .
+	docker build \
+		--no-cache \
+		--build-arg SATURNBASE_GPU_IMAGE=${SATURNBASE_GPU_IMAGE} \
+		-t ${IMAGE} \
+		.

--- a/saturn/Makefile
+++ b/saturn/Makefile
@@ -2,4 +2,8 @@ include .env_deps
 export
 
 build_image:
-	docker build --build-arg SATURNBASE_IMAGE=${SATURNBASE_IMAGE} -t ${IMAGE} .
+	docker build \
+		--no-cache \
+		--build-arg SATURNBASE_IMAGE=${SATURNBASE_IMAGE} \
+		-t ${IMAGE} \
+		.

--- a/saturnbase-gpu/Makefile
+++ b/saturnbase-gpu/Makefile
@@ -2,4 +2,8 @@ include .env_deps
 export
 
 build_image:
-	docker build --build-arg JUPYTER_SATURN_VERSION=${JUPYTER_SATURN_VERSION} -t ${IMAGE} .
+	docker build \
+		--no-cache \
+		--build-arg JUPYTER_SATURN_VERSION=${JUPYTER_SATURN_VERSION} \
+		-t ${IMAGE} \
+		.

--- a/saturnbase/Makefile
+++ b/saturnbase/Makefile
@@ -2,4 +2,8 @@ include .env_deps
 export
 
 build_image:
-	docker build --build-arg JUPYTER_SATURN_VERSION=${JUPYTER_SATURN_VERSION} -t ${IMAGE} .
+	docker build \
+		--no-cache \
+		--build-arg JUPYTER_SATURN_VERSION=${JUPYTER_SATURN_VERSION} \
+		-t ${IMAGE} \
+		.


### PR DESCRIPTION
This PR proposes changing the strategy for image building, to be sure that images are always built from scratch ignoring the Docker cache.

### Changes in this PR

Adds `--no-cache` to every `docker build` command in the project.

### How this improves `images`

Ignoring the cache means that the content of an image is less dependent on where it's built and whether it was built (or partially built) previously.