### PR TITLE
[DEV-1785] update base images' conda versions, consolidate RUN steps

### DIFF
--- a/saturnbase-gpu/Dockerfile
+++ b/saturnbase-gpu/Dockerfile
@@ -35,8 +35,8 @@ RUN apt-get -qq update && \
     apt-get -qq clean && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /run/sshd && \
-    chmod 755 /run/sshd
-RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    chmod 755 /run/sshd && \
+    echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     locale-gen
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
@@ -50,10 +50,9 @@ ENV HOME=/home/${NB_USER}
 RUN adduser --disabled-password \
     --gecos "Default user" \
     --uid ${NB_UID} \
-    ${NB_USER}
-
-RUN echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook
-RUN mkdir -p ${APP_BASE} && \
+    ${NB_USER} && \
+    echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook && \
+    mkdir -p ${APP_BASE} && \
     chown -R $NB_USER:$NB_USER ${APP_BASE}
 USER ${NB_USER}
 
@@ -62,11 +61,10 @@ RUN bash /tmp/install-miniconda.bash
 
 COPY install-jupyter.bash /tmp/install-jupyter.bash
 COPY environment.yml /tmp/environment-temp.yml
-RUN envsubst < /tmp/environment-temp.yml > /tmp/environment.yml
-RUN bash /tmp/install-jupyter.bash
-
-RUN echo '' > ${CONDA_DIR}/conda-meta/history
-RUN ${CONDA_BIN}/conda config --system --add channels conda-forge && \
+RUN envsubst < /tmp/environment-temp.yml > /tmp/environment.yml && \
+    bash /tmp/install-jupyter.bash && \
+    echo '' > ${CONDA_DIR}/conda-meta/history && \
+    ${CONDA_BIN}/conda config --system --add channels conda-forge && \
     ${CONDA_BIN}/conda config --system --add channels https://conda.saturncloud.io/pkgs && \
     ${CONDA_BIN}/conda config --system --set auto_update_conda false && \
     ${CONDA_BIN}/conda config --system --set show_channel_urls true

--- a/saturnbase-gpu/install-miniconda.bash
+++ b/saturnbase-gpu/install-miniconda.bash
@@ -4,7 +4,7 @@ set -ex
 
 cd $(dirname $0)
 
-MINICONDA_VERSION=py37_4.8.2
+MINICONDA_VERSION=py37_4.9.3
 URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
 INSTALLER_PATH=/tmp/miniconda-installer.sh
 wget --quiet $URL -O ${INSTALLER_PATH}
@@ -20,6 +20,9 @@ fi
 bash ${INSTALLER_PATH} -b -p ${CONDA_DIR} -f
 
 export PATH="${CONDA_BIN}:$PATH"
+
+# Update conda
+conda update -y conda
 
 # Allow easy direct installs from conda forge
 conda config --system --add channels conda-forge

--- a/saturnbase-gpu/install-miniconda.bash
+++ b/saturnbase-gpu/install-miniconda.bash
@@ -4,7 +4,7 @@ set -ex
 
 cd $(dirname $0)
 
-MINICONDA_VERSION=py37_4.9.3
+MINICONDA_VERSION=py37_4.9.2
 URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
 INSTALLER_PATH=/tmp/miniconda-installer.sh
 wget --quiet $URL -O ${INSTALLER_PATH}

--- a/saturnbase/Dockerfile
+++ b/saturnbase/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:4.8.2
+FROM continuumio/miniconda3:4.9.2
 EXPOSE 8888
 
 ARG JUPYTER_SATURN_VERSION
@@ -30,9 +30,10 @@ RUN apt-get -qq update && \
     apt-get -qq purge && \
     apt-get -qq clean && \
     rm -rf /var/lib/apt/lists/* && \
+    conda update -y conda && \
     mkdir -p /run/sshd && \
-    chmod 755 /run/sshd
-RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    chmod 755 /run/sshd && \
+    echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     locale-gen
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
@@ -46,10 +47,9 @@ ENV HOME=/home/${NB_USER}
 RUN adduser --disabled-password \
     --gecos "Default user" \
     --uid ${NB_UID} \
-    ${NB_USER}
-
-RUN echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook
-RUN mkdir -p ${APP_BASE} && \
+    ${NB_USER} && \
+    echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook && \
+    mkdir -p ${APP_BASE} && \
     chown -R $NB_USER:$NB_USER ${APP_BASE}
 COPY profile /etc/profile
 
@@ -57,10 +57,10 @@ USER ${NB_USER}
 
 COPY install-jupyter.bash /tmp/install-jupyter.bash
 COPY environment.yml /tmp/environment-temp.yml
-RUN envsubst < /tmp/environment-temp.yml > /tmp/environment.yml
-RUN bash /tmp/install-jupyter.bash
-RUN echo '' > ${CONDA_DIR}/conda-meta/history
-RUN ${CONDA_BIN}/conda config --system --add channels conda-forge && \
+RUN envsubst < /tmp/environment-temp.yml > /tmp/environment.yml && \
+    bash /tmp/install-jupyter.bash && \
+    echo '' > ${CONDA_DIR}/conda-meta/history && \
+    ${CONDA_BIN}/conda config --system --add channels conda-forge && \
     ${CONDA_BIN}/conda config --system --add channels https://conda.saturncloud.io/pkgs && \
     ${CONDA_BIN}/conda config --system --set auto_update_conda false && \
     ${CONDA_BIN}/conda config --system --set show_channel_urls true


### PR DESCRIPTION
This PR makes two connected changes:

1. Update the conda version our base images use to 4.9.2, and add a `conda update conda` step to both to keep it updated (for DEV-1785).
2. While adding the `conda update conda` calls, I added them to preexisting `RUN` steps so that we don't create additional layers (meaning our overall image is smaller) - and in the process noted that there were additional `RUN` steps in both that could be combined for consistency (and further minor size reduction). Small change - happy to split it out if we think there's good reason to.