### PR TITLE
remove old saturn conda channel

### DIFF
--- a/saturnbase-gpu/Dockerfile
+++ b/saturnbase-gpu/Dockerfile
@@ -65,7 +65,6 @@ RUN envsubst < /tmp/environment-temp.yml > /tmp/environment.yml && \
     bash /tmp/install-jupyter.bash && \
     echo '' > ${CONDA_DIR}/conda-meta/history && \
     ${CONDA_BIN}/conda config --system --add channels conda-forge && \
-    ${CONDA_BIN}/conda config --system --add channels https://conda.saturncloud.io/pkgs && \
     ${CONDA_BIN}/conda config --system --set auto_update_conda false && \
     ${CONDA_BIN}/conda config --system --set show_channel_urls true
 ENV NPM_DIR ${APP_BASE}/npm

--- a/saturnbase-gpu/environment.yml
+++ b/saturnbase-gpu/environment.yml
@@ -1,7 +1,6 @@
 channels:
   - defaults
   - conda-forge
-  - https://conda.saturncloud.io/pkgs
   - saturncloud
 dependencies:
   - nodejs=11

--- a/saturnbase-gpu/install-miniconda.bash
+++ b/saturnbase-gpu/install-miniconda.bash
@@ -26,6 +26,5 @@ conda update -y conda
 
 # Allow easy direct installs from conda forge
 conda config --system --add channels conda-forge
-conda config --system --add channels https://conda.saturncloud.io/pkgs
 conda config --system --set auto_update_conda false
 conda config --system --set show_channel_urls true

--- a/saturnbase/Dockerfile
+++ b/saturnbase/Dockerfile
@@ -61,7 +61,6 @@ RUN envsubst < /tmp/environment-temp.yml > /tmp/environment.yml && \
     bash /tmp/install-jupyter.bash && \
     echo '' > ${CONDA_DIR}/conda-meta/history && \
     ${CONDA_BIN}/conda config --system --add channels conda-forge && \
-    ${CONDA_BIN}/conda config --system --add channels https://conda.saturncloud.io/pkgs && \
     ${CONDA_BIN}/conda config --system --set auto_update_conda false && \
     ${CONDA_BIN}/conda config --system --set show_channel_urls true
 ENV NPM_DIR ${APP_BASE}/npm

--- a/saturnbase/environment.yml
+++ b/saturnbase/environment.yml
@@ -1,7 +1,6 @@
 channels:
   - defaults
   - conda-forge
-  - https://conda.saturncloud.io/pkgs
   - saturncloud
 dependencies:
   - nodejs=11


### PR DESCRIPTION
This proposes removing `https://conda.saturncloud.io/pkgs` from the list of channels searched by `conda` in the `saturnbase` and `saturnbase-gpu` images.

That channel has been unused for a while (last update: October 2019) and these images don't depend on anything from there.

## How this improves images

Might improve build times by reducing the search space for packages.

Prevents the possibility of accidentally getting an old package due to a weird environment solve.

Removes a possible source of supply chain attacks, where someone could try to sneak malicious code into Saturn images by uploading it to that conda channel.