### PR TITLE
Fix /opt/conda permissions in saturnbase image

### DIFF
--- a/saturnbase-gpu/Dockerfile
+++ b/saturnbase-gpu/Dockerfile
@@ -6,8 +6,7 @@ ARG JUPYTER_SATURN_VERSION
 ENV JUPYTER_SATURN_VERSION=${JUPYTER_SATURN_VERSION}
 
 RUN mkdir /opt/conda && \
-    ln -s /opt/conda /srv/conda && \
-    chown 1000:1000 -R /opt/conda
+    ln -s /opt/conda /srv/conda
 ENV APP_BASE=/srv
 ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin
@@ -53,6 +52,7 @@ RUN adduser --disabled-password \
     ${NB_USER} && \
     echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook && \
     mkdir -p ${APP_BASE} && \
+    chown 1000:1000 -R /opt/conda && \
     chown -R $NB_USER:$NB_USER ${APP_BASE}
 USER ${NB_USER}
 

--- a/saturnbase/Dockerfile
+++ b/saturnbase/Dockerfile
@@ -5,7 +5,7 @@ ARG JUPYTER_SATURN_VERSION
 
 ENV JUPYTER_SATURN_VERSION=${JUPYTER_SATURN_VERSION}
 
-RUN ln -s /opt/conda /srv/conda && chown 1000:1000 -R /opt/conda
+RUN ln -s /opt/conda /srv/conda
 ENV APP_BASE=/srv
 ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin
@@ -50,6 +50,7 @@ RUN adduser --disabled-password \
     ${NB_USER} && \
     echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook && \
     mkdir -p ${APP_BASE} && \
+    chown 1000:1000 -R /opt/conda && \
     chown -R $NB_USER:$NB_USER ${APP_BASE}
 COPY profile /etc/profile
 


### PR DESCRIPTION
Builds of `saturnbase` on the `release-2021.04.19` branch were failing due to: `[Errno 13] Permission denied: '/opt/conda/lib/python3.8/site-packages/conda-4.10.1-py3.8.egg-info/PKG-INFO' -> '/opt/conda/lib/python3.8/site-packages/conda-4.10.1-py3.8.egg-info/PKG-INFO.c~'`

This error had gone undetected because we had paused builds on these images after the `02.22` branch. However, I inadvertently built this branch today and discovered this.

The issue was indirectly caused by the change in #181 to call `conda update conda` - meaning that the files created by that upgrade are owned by `root`, even though `/opt/conda` was previously `chown`'d to UID 1000.  Somehow, one of our dependencies is now upgrading a child dependency that it shares with `conda` - and, since the `conda update` for the environment runs as non-root, it was unable to remove the old version.

This PR addresses the issue by moving the recursive `/opt/conda` `chown` to be _after_ the `conda update conda` call in the `saturnbase` image. I've made an identical change in the `saturnbase-gpu` image for parity, but it won't actually affect anything (`conda update conda` has to be called by UID 1000 in that image) - just for readability.