### PR TITLE
Run 'apt-get upgrade' in base image builds

### DIFF
--- a/saturnbase-gpu/Dockerfile
+++ b/saturnbase-gpu/Dockerfile
@@ -13,6 +13,7 @@ ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -qq update && \
+    apt-get -qq upgrade -y && \
     apt-get -qq install --yes --no-install-recommends \
         gettext-base \
         gnupg \

--- a/saturnbase/Dockerfile
+++ b/saturnbase/Dockerfile
@@ -11,6 +11,7 @@ ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -qq update && \
+    apt-get -qq upgrade -y && \
     apt-get -qq install --yes --no-install-recommends \
         gettext-base \
         gnupg \


### PR DESCRIPTION
Docker scans are showing a large number of vulnerabilities on our older images. This PR adds called to `apt-get upgrade` to our two base images to resolve the vast majority of these issues.