### PR TITLE
Feat/update rapids

### DIFF
--- a/saturn-rapids/environment.yml
+++ b/saturn-rapids/environment.yml
@@ -9,8 +9,8 @@ dependencies:
 - bokeh
 - cvxpy
 - dask-ml
-- dask=2.30.0
-- distributed=2.30.1
+- dask=2021.4.0
+- distributed=2021.4.0
 - ipykernel
 - ipywidgets
 - matplotlib
@@ -22,12 +22,12 @@ dependencies:
 - pyarrow
 - python=3.7
 - python-graphviz
-- rapids=0.17.0=cuda10.1_py37_g180f433_165
+- rapids-blazing=0.19.0=cuda10.1_py37_ga03647d_299
 - s3fs
 - scikit-learn
 - scipy
 - voila
-- xgboost=1.3.0dev.rapidsai0.17=cuda10.1py37_0
+- xgboost=1.4.0dev.rapidsai0.19=cuda10.1py37_0
 - pip:
   - dask-saturn>=0.2.3
   - prefect-saturn>=0.5.0

--- a/saturnbase-gpu/environment.yml
+++ b/saturnbase-gpu/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - isort
   - tornado=6
   - jupyter_saturn=${JUPYTER_SATURN_VERSION}
+  - jupyterlab-nvdashboard==0.5.0
   - nbdime
   - pyyaml
   - voila

--- a/saturnbase-gpu/install-jupyter.bash
+++ b/saturnbase-gpu/install-jupyter.bash
@@ -21,6 +21,7 @@ jupyter labextension install @pyviz/jupyterlab_pyviz
 jupyter labextension install jupyterlab-execute-time
 jupyter labextension install @telamonian/theme-darcula
 jupyter labextension install jupyterlab-python-file
+jupyter labextension install jupyterlab-nvdashboard
 
 cd ${CONDA_DIR}/jsaturn_ext
 npm install


### PR DESCRIPTION
- Add nvdashboard to base GPU images
- Update RAPIDS to 0.19

Images are in dockerhub with the tag `update-rapids`:
- saturncloud/saturn-rapids:update-rapids
- saturncloud/saturn-pytorch:update-rapids