### PR TITLE
add '--allow-releaseinfo-change' to apt updates

### DIFF
--- a/saturn-r/postBuild
+++ b/saturn-r/postBuild
@@ -1,7 +1,7 @@
 # https://cran.rstudio.com/bin/linux/debian/
 sudo apt-key adv --keyserver keys.gnupg.net --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF'
 
-sudo apt update
+sudo apt --allow-releaseinfo-change update
 sudo apt install -y \
     --no-install-recommends \
         software-properties-common
@@ -9,7 +9,7 @@ sudo apt install -y \
 sudo su -c \
     "echo 'deb http://cloud.r-project.org/bin/linux/debian buster-cran40/' >>/etc/apt/sources.list"
 
-sudo apt update
+sudo apt --allow-releaseinfo-change update
 sudo apt install -y -t buster-cran40 \
     r-base \
     r-base-dev 

--- a/saturnbase-gpu-10.1/Dockerfile
+++ b/saturnbase-gpu-10.1/Dockerfile
@@ -7,7 +7,7 @@ ENV APP_BASE=/srv
 ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -qq update && \
+RUN apt-get -qq --allow-releaseinfo-change update && \
     apt-get -qq upgrade -y && \
     apt-get -qq install --yes --no-install-recommends \
         gettext-base \

--- a/saturnbase-gpu-11.1/Dockerfile
+++ b/saturnbase-gpu-11.1/Dockerfile
@@ -11,7 +11,7 @@ ENV APP_BASE=/srv
 ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -qq update && \
+RUN apt-get -qq --allow-releaseinfo-change update && \
     apt-get -qq upgrade -y && \
     apt-get -qq install --yes --no-install-recommends \
         gettext-base \

--- a/saturnbase/Dockerfile
+++ b/saturnbase/Dockerfile
@@ -6,7 +6,7 @@ ENV APP_BASE=/srv
 ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -qq update && \
+RUN apt-get -qq --allow-releaseinfo-change update && \
     apt-get -qq upgrade -y && \
     apt-get -qq install --yes --no-install-recommends \
         gettext-base \


### PR DESCRIPTION
This will allow these images to be rebuilt on `miniconda3-4.9.2` the next time that's needed.

This was tested in `release-images` (can provide the link via DM - this is a public repo).