### PR TITLE
Docker container with RStudio

### DIFF
--- a/saturn-r/.env_deps
+++ b/saturn-r/.env_deps
@@ -1,3 +1,3 @@
-VERSION=2021.04.19-1
-SATURNBASE_IMAGE=saturncloud/saturnbase:2021.02.22
-IMAGE=saturncloud/saturn-r:2021.04.19-1
+VERSION=2021.07.26
+SATURNBASE_IMAGE=saturncloud/saturnbase:2021.07.26
+IMAGE=saturncloud/saturn-r:2021.07.26

--- a/saturn-r/postBuild
+++ b/saturn-r/postBuild
@@ -1,14 +1,18 @@
 # https://cran.rstudio.com/bin/linux/debian/
 
-sudo apt update
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF'
+
+sudo apt --allow-releaseinfo-change update
 sudo apt install -y \
     --no-install-recommends \
         software-properties-common
 
-sudo apt update
-sudo apt install -y \
+sudo su -c \
+    "echo 'deb http://cloud.r-project.org/bin/linux/debian buster-cran40/' >>/etc/apt/sources.list"
+
+sudo apt  update
+sudo apt install -y -t buster-cran40 \
     r-base \
-    r-base-dev \
     r-base-core \
     r-base-dev 
 

--- a/saturn-r/postBuild
+++ b/saturn-r/postBuild
@@ -1,17 +1,15 @@
 # https://cran.rstudio.com/bin/linux/debian/
-sudo apt-key adv --keyserver keys.gnupg.net --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF'
 
 sudo apt update
 sudo apt install -y \
     --no-install-recommends \
         software-properties-common
 
-sudo su -c \
-    "echo 'deb http://cloud.r-project.org/bin/linux/debian buster-cran40/' >>/etc/apt/sources.list"
-
 sudo apt update
-sudo apt install -y -t buster-cran40 \
+sudo apt install -y \
     r-base \
+    r-base-dev \
+    r-base-core \
     r-base-dev 
 
 sudo apt install -y \

--- a/saturn-r/postBuild
+++ b/saturn-r/postBuild
@@ -10,7 +10,7 @@ sudo apt install -y \
 sudo su -c \
     "echo 'deb http://cloud.r-project.org/bin/linux/debian buster-cran40/' >>/etc/apt/sources.list"
 
-sudo apt  update
+sudo apt update
 sudo apt install -y -t buster-cran40 \
     r-base \
     r-base-core \

--- a/saturnbase-rstudio/.dockerignore
+++ b/saturnbase-rstudio/.dockerignore
@@ -1,0 +1,4 @@
+*
+!rserver.conf
+!rstudio-prefs.json
+!startup.sh

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -1,0 +1,81 @@
+FROM rocker/r-ver:4.1.0
+
+# hadolint ignore=DL3008,DL3009
+RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends \
+        bzip2 \
+        ca-certificates \
+        gdebi-core \
+        git \
+        libcap2 \
+        libglib2.0-0 \
+        libpq5 \
+        libsm6 \
+        libssl1.1 \
+        openssl \
+        libssl-dev \
+        libuser \
+        libuser1-dev \
+        libxext6 \
+        libxrender1 \
+        openssh-client \
+        rrdtool \
+	sudo \
+        wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends curl
+# Install Python --------------------------------------------------------------#
+
+ARG PYTHON_VERSION=3.9.5
+RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh && \
+    bash Miniconda3-4.7.12.1-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
+    /opt/python/${PYTHON_VERSION}/bin/conda install -y python==${PYTHON_VERSION} && \
+    /opt/python/${PYTHON_VERSION}/bin/pip install \
+        ipykernel \
+        virtualenv \
+        && \
+    rm -rf Miniconda3-*-Linux-x86_64.sh && \
+    /opt/python/${PYTHON_VERSION}/bin/python -m ipykernel install --name py${PYTHON_VERSION} --display-name "Python ${PYTHON_VERSION}"
+
+# Install RStudio Server Pro --------------------------------------------------#
+ARG RSW_VERSION=1.4.1717-3
+ARG RSW_DOWNLOAD_URL=https://download2.rstudio.org/server/bionic/amd64
+ARG RSW_NAME=rstudio-workbench
+RUN apt-get update --fix-missing \
+    && RSW_VERSION_URL=`echo -n "${RSW_VERSION}" | sed 's/+/%2B/g'` \
+    && curl -o rstudio-workbench.deb ${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION_URL}-amd64.deb \
+    && gdebi --non-interactive rstudio-workbench.deb \
+    && rm rstudio-workbench.deb \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /var/lib/rstudio-server/r-versions
+
+# Runtime settings ------------------------------------------------------------#
+ARG TINI_VERSION=0.18.0
+RUN curl -L -o /usr/local/bin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini && \
+    chmod +x /usr/local/bin/tini
+
+RUN curl -L -o /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && \
+    chmod +x /usr/local/bin/wait-for-it.sh
+
+# Copy startup
+COPY startup.sh /usr/local/bin/startup.sh
+RUN chmod +x /usr/local/bin/startup.sh
+
+COPY rserver.conf /etc/rstudio/rserver.conf
+COPY rstudio-prefs.json /etc/rstudio/rstudio-prefs.json
+
+# IP address of the licensing server
+ENV RSW_LICENSE_SERVER ""
+
+# the user info for the RStudio user
+ENV RSW_USER saturn
+ENV RSW_USER_PASSWD saturn
+ENV RSW_USER_UID 10000
+
+# the port the container listens to. Expose whatever port you set here.
+ENV RSW_PORT = 8787 
+
+ENTRYPOINT ["tini", "--"]
+CMD ["/usr/local/bin/startup.sh"]

--- a/saturnbase-rstudio/README.md
+++ b/saturnbase-rstudio/README.md
@@ -1,0 +1,22 @@
+# RStudio Base image
+
+This image lets you run RStudio in a docker container, so that eventually it will be an alternative to JupyterLab.
+
+The docker container uses a central licensing server to get it's license. It has a special `saturn` user with password `saturn` to log in with (this can be changed via env vars).
+
+Currently, we have a test licensing server running in an EC2 instance of our AWS account at the address `3.142.146.194`.
+
+To run the container, use the following docker command:
+
+```
+docker run --privileged -t -d -p 8787:8787 -e RSW_LICENSE_SERVER=3.142.146.194 saturnbase-rstudio
+```
+
+To try it, then navigate to `localhost:8787` and log in with username `saturn` and password `saturn`.
+
+## To do
+
+1. Make it so when you go to the URL it drops you directly into RStudio without having to log in
+2. Set this up for GPUs
+3. Have the python installation in the correct location for use by Saturn Cloud setup
+4. Set the user attributes correctly (name, UID) for Saturn

--- a/saturnbase-rstudio/README.md
+++ b/saturnbase-rstudio/README.md
@@ -1,22 +1,20 @@
 # RStudio Base image
 
-This image lets you run RStudio in a docker container, so that eventually it will be an alternative to JupyterLab.
+This image lets you run RStudio Workbench in a docker container, so that eventually it will be an alternative to JupyterLab.
 
 The docker container uses a central licensing server to get it's license. It has a special `saturn` user with password `saturn` to log in with (this can be changed via env vars).
-
-Currently, we have a test licensing server running in an EC2 instance of our AWS account at the address `3.142.146.194`.
 
 To run the container, use the following docker command:
 
 ```
-docker run --privileged -t -d -p 8787:8787 -e RSW_LICENSE_SERVER=3.142.146.194 saturnbase-rstudio
+docker run --privileged -t -d -p 8787:8787 -e RSW_LICENSE_SERVER={ip-of-license-server} saturnbase-rstudio
 ```
 
 To try it, then navigate to `localhost:8787` and log in with username `saturn` and password `saturn`.
 
 ## To do
 
-1. Make it so when you go to the URL it drops you directly into RStudio without having to log in
+1. ~Make it so when you go to the URL it drops you directly into RStudio without having to log in~ fixed
 2. Set this up for GPUs
 3. Have the python installation in the correct location for use by Saturn Cloud setup
 4. Set the user attributes correctly (name, UID) for Saturn

--- a/saturnbase-rstudio/rserver.conf
+++ b/saturnbase-rstudio/rserver.conf
@@ -1,1 +1,3 @@
 server-license-type=remote
+auth-none=1
+auth-validate-users=0

--- a/saturnbase-rstudio/rserver.conf
+++ b/saturnbase-rstudio/rserver.conf
@@ -1,0 +1,1 @@
+server-license-type=remote

--- a/saturnbase-rstudio/rstudio-prefs.json
+++ b/saturnbase-rstudio/rstudio-prefs.json
@@ -1,0 +1,3 @@
+{
+    "show_user_home_page": "never"
+}

--- a/saturnbase-rstudio/startup.sh
+++ b/saturnbase-rstudio/startup.sh
@@ -8,6 +8,9 @@ unset RSW_LICENSE_SERVER
 
 echo "www-port=$RSW_PORT" >> rserver.conf
 
+# this is so RStudio knows which user to log in as since we aren't authenticating
+export USER=$RSW_USER
+
 # Deactivate license when it exists
 deactivate() {
     echo "== Exiting =="

--- a/saturnbase-rstudio/startup.sh
+++ b/saturnbase-rstudio/startup.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -e
+set -x
+
+/usr/lib/rstudio-server/bin/license-manager license-server $RSW_LICENSE_SERVER
+unset RSW_LICENSE_SERVER
+
+echo "www-port=$RSW_PORT" >> rserver.conf
+
+# Deactivate license when it exists
+deactivate() {
+    echo "== Exiting =="
+    rstudio-server stop
+
+    echo " --> TAIL 100 rstudio-server.log"
+    tail -n 100 /var/log/rstudio-server.log
+    echo " --> TAIL 100 rstudio-kubernetes-launcher.log"
+    tail -n 100 /var/lib/rstudio-launcher/Kubernetes/rstudio-kubernetes-launcher.log
+    echo " --> TAIL 100 rstudio-local-launcher*.log"
+    tail -n 100 /var/lib/rstudio-launcher/Local/rstudio-local-launcher*.log
+    echo " --> TAIL 100 rstudio-launcher.log"
+    tail -n 100 /var/lib/rstudio-launcher/rstudio-launcher.log
+    echo " --> TAIL 100 monitor/log/rstudio-server.log"
+    tail -n 100 /var/lib/rstudio-server/monitor/log/rstudio-server.log
+
+    echo "Deactivating license ..."
+    /usr/lib/rstudio-server/bin/license-manager deactivate >/dev/null 2>&1
+
+    echo "== Done =="
+}
+trap deactivate EXIT
+
+# touch log files to initialize them
+su rstudio-server -c 'touch /var/lib/rstudio-server/monitor/log/rstudio-server.log'
+mkdir -p /var/lib/rstudio-launcher
+chown rstudio-server:rstudio-server /var/lib/rstudio-launcher
+su rstudio-server -c 'touch /var/lib/rstudio-launcher/rstudio-launcher.log'
+touch /var/log/rstudio-server.log
+mkdir -p /var/lib/rstudio-launcher/Local
+chown rstudio-server:rstudio-server /var/lib/rstudio-launcher/Local
+su rstudio-server -c 'touch /var/lib/rstudio-launcher/Local/rstudio-local-launcher-placeholder.log'
+mkdir -p /var/lib/rstudio-launcher/Kubernetes
+chown rstudio-server:rstudio-server /var/lib/rstudio-launcher/Kubernetes
+su rstudio-server -c 'touch /var/lib/rstudio-launcher/Kubernetes/rstudio-kubernetes-launcher.log'
+
+# Create one user
+if [ $(getent passwd $RSW_USER_UID) ] ; then
+    echo "UID $RSW_USER_UID already exists, not creating $RSW_USER test user";
+else
+    if [ -z "$RSW_USER" ]; then
+        echo "Empty 'RSW_USER' variables, not creating test user";
+    else
+        useradd -m -s /bin/bash -N -u $RSW_USER_UID $RSW_USER
+        echo "$RSW_USER:$RSW_USER_PASSWD" | sudo chpasswd
+    fi
+fi
+
+tail -n 100 -f \
+  /var/lib/rstudio-server/monitor/log/*.log \
+  /var/lib/rstudio-launcher/*.log \
+  /var/lib/rstudio-launcher/Local/*.log \
+  /var/lib/rstudio-launcher/Kubernetes/*.log \
+  /var/log/rstudio-launcher.log \
+  /var/log/rstudio-server.log &
+
+# the main container process
+# cannot use "exec" or the "trap" will be lost
+/usr/lib/rstudio-server/bin/rserver --server-daemonize 0 > /var/log/rstudio-server.log 2>&1


### PR DESCRIPTION
# RStudio Base image

This image lets you run RStudio in a docker container, so that eventually it will be an alternative to JupyterLab.

The docker container uses a central licensing server to get it's license. It has a special `saturn` user with password `saturn` to log in with (this can be changed via env vars).

To run the container, use the following docker command:

```
docker run --privileged -t -d -p 8787:8787 -e RSW_LICENSE_SERVER=<license-server-ip> saturnbase-rstudio
```

To try it, then navigate to `localhost:8787` and log in with username `saturn` and password `saturn`.

## To do

1. Set this up for GPUs
3. Have the python installation in the correct location for use by Saturn Cloud setup
4. Set the user attributes correctly (name, UID) for Saturn
