### PR TITLE
made gpu environment.yml files consistent

### DIFF
--- a/saturnbase-gpu-10.1/environment.yml
+++ b/saturnbase-gpu-10.1/environment.yml
@@ -15,9 +15,10 @@ dependencies:
   - dask-labextension
   - yarl
   - pyviz_comms
-  - jupyterlab_code_formatter
+  - jupyterlab_code_formatter=1.3.8
   - black
   - isort
-  - tornado
+  - tornado=6
+  - jupyterlab-nvdashboard==0.5.0
   - nbdime
   - voila

--- a/saturnbase-gpu-11.2/environment.yml
+++ b/saturnbase-gpu-11.2/environment.yml
@@ -15,9 +15,10 @@ dependencies:
   - dask-labextension
   - yarl
   - pyviz_comms
-  - jupyterlab_code_formatter
+  - jupyterlab_code_formatter=1.3.8
   - black
   - isort
-  - tornado
+  - tornado=6
+  - jupyterlab-nvdashboard==0.5.0
   - nbdime
   - voila


### PR DESCRIPTION
In attempting to track down this bug, I discovered (well Hugo discovered), it's because we specify the code formatter version in the environment.yml file for only some of the GPU images. When going to fix it, I noticed that between the CUDA 10.1, 11.1, and 11.2 images there were a few other inconsistencies with the environment.yml files. This PR makes them all have the exact same version of environment.yml

Once this PR is approved, we'll need to update the base images, then update at least the `saturn-rapids` image too, since that is where this bug was showing up

![image](https://user-images.githubusercontent.com/3317138/135634902-803385f3-cedb-41f6-bbf4-50a89f7472a8.png)
