### PR TITLE
bumping dask-cuda version to match dask version

### DIFF
--- a/saturn-pytorch/environment.yml
+++ b/saturn-pytorch/environment.yml
@@ -10,7 +10,7 @@ dependencies:
 - bokeh
 - dask=2021.07
 - distributed=2021.07
-- dask-cuda=0.19
+- dask-cuda=21.8
 - fastai
 - fsspec>=0.8.5
 - ipykernel

--- a/saturn-tensorflow/environment.yml
+++ b/saturn-tensorflow/environment.yml
@@ -8,7 +8,7 @@ dependencies:
 - bokeh
 - dask=2021.07
 - distributed=2021.07
-- dask-cuda=0.19
+- dask-cuda==21.8
 - fsspec
 - ipykernel
 - ipywidgets


### PR DESCRIPTION
This PR bumps the dask-cuda version to 21.8 which matches the dask version of 21.7 that is set in the saturn-pytorch and saturn-tensorflow images. No change is needed for saturn-rapids because saturn-rapids installs the rapids metapackage which controls dask-cuda and dask.

If you'd like to test - once new dask-pytorch and dask-tensorflow images are built, you will see that dask clusters work again. Previously, `dask-cuda` errors out. You also could not import it.