### PR TITLE
Removed requirement for startup script with R

### DIFF
--- a/saturn-r/postBuild
+++ b/saturn-r/postBuild
@@ -52,3 +52,6 @@ sudo Rscript -e "install.packages(c( \
     ), Ncpus = max(c(1, parallel::detectCores() - 1)), \
     dependencies = c('LinkingTo', 'Depends', 'Imports') \
     )"
+
+# Set up R kernel for Jupyter
+RUN Rscript -e "IRkernel::installspec(user = FALSE)"

--- a/saturn-r/postBuild
+++ b/saturn-r/postBuild
@@ -54,4 +54,4 @@ sudo Rscript -e "install.packages(c( \
     )"
 
 # Set up R kernel for Jupyter
-RUN Rscript -e "IRkernel::installspec(user = FALSE)"
+sudo Rscript -e "IRkernel::installspec(user = FALSE)"


### PR DESCRIPTION
Previously, the R image required a specific command in the startup script to register R with the jupyter server. This was fairly frustrating since users could easily forget to add it. I believe this does the step correctly during the image build so we don't have to do it at startup.