### PR TITLE
Replace devel base image with runtime

### DIFF
--- a/saturnbase-gpu-10.1/Dockerfile
+++ b/saturnbase-gpu-10.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.1-devel-ubuntu18.04
+FROM nvidia/cuda:10.1-runtime-ubuntu18.04
 EXPOSE 8888
 
 RUN mkdir /opt/conda && \

--- a/saturnbase-gpu-11.1/Dockerfile
+++ b/saturnbase-gpu-11.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.1.1-devel-ubuntu18.04
+FROM nvidia/cuda:11.1.1-runtime-ubuntu18.04
 EXPOSE 8888
 
 ARG JUPYTER_SATURN_VERSION

--- a/saturnbase-gpu-11.2/Dockerfile
+++ b/saturnbase-gpu-11.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.2.1-devel-ubuntu18.04
+FROM nvidia/cuda:11.2.1-runtime-ubuntu18.04
 EXPOSE 8888
 
 RUN mkdir /opt/conda && \


### PR DESCRIPTION
We have been building off of the devel (a.k.a development) nvidia/cuda image, which contains a lot of things we don't need. Replacing with the runtime version of the image.

For the saturnbase-gpu-11.2 image, this resulted in a size of `3.87GB`, compared to the 2021.09.20 build which is `6.42GB`.