### PR TITLE
Extra packages for RMarkdown in RStudio

### DIFF
--- a/saturn-rstudio/Dockerfile
+++ b/saturn-rstudio/Dockerfile
@@ -33,6 +33,15 @@ RUN sudo apt-get update --fix-missing \
     && sudo curl -L -o /usr/local/bin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini \
     && sudo chmod +x /usr/local/bin/tini
 
+# Add a few R packages that are useful for RMarkdown
+RUN Rscript -e "install.packages(c( \
+       'jquerylib', \
+       'markdown', \
+       'rmarkdown', \
+       'tinytex' \
+    ), Ncpus = max(c(1, parallel::detectCores() - 1)), \
+    dependencies = c('LinkingTo', 'Depends', 'Imports') \
+    )"
 
 COPY --chown=root:root rstudio-start.sh /usr/local/bin/rstudio-start.sh
 RUN sudo chmod +x /usr/local/bin/rstudio-start.sh

--- a/saturn-rstudio/Dockerfile
+++ b/saturn-rstudio/Dockerfile
@@ -40,7 +40,8 @@ RUN Rscript -e "install.packages(c( \
        'rmarkdown', \
        'tinytex' \
     ), Ncpus = max(c(1, parallel::detectCores() - 1)), \
-    dependencies = c('LinkingTo', 'Depends', 'Imports') \
+    dependencies = c('LinkingTo', 'Depends', 'Imports'), \
+    lib = '/usr/local/lib/R/site-library' \
     )"
 
 COPY --chown=root:root rstudio-start.sh /usr/local/bin/rstudio-start.sh


### PR DESCRIPTION
This is a minor set of additions to the RStudio image that lets users compile RMarkdown files without having to first install new packages.

This is in the `saturn-rstudio` image and not the `saturn-r` image since generally (but not always), you only use RMarkdown in interactive environments.