### PR TITLE
Use bullseye repos for saturn-r

### DIFF
--- a/saturn-r/postBuild
+++ b/saturn-r/postBuild
@@ -2,16 +2,16 @@
 
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF'
 
-sudo apt --allow-releaseinfo-change update
+sudo apt update
 sudo apt install -y \
     --no-install-recommends \
         software-properties-common
 
 sudo su -c \
-    "echo 'deb http://cloud.r-project.org/bin/linux/debian buster-cran40/' >>/etc/apt/sources.list"
+    "echo 'deb http://cloud.r-project.org/bin/linux/debian bullseye-cran40/' >>/etc/apt/sources.list"
 
-sudo apt --allow-releaseinfo-change update
-sudo apt install -y -t buster-cran40 \
+sudo apt update
+sudo apt install -y -t bullseye-cran40 \
     r-base \
     r-base-core \
     r-base-dev 


### PR DESCRIPTION
This PR swaps the saturn-r build to use the bullseye repos (which were unavailable for cran40 when we initially did the bullseye upgrade), and removes the no-longer-needed `--allow-releaseinfo-change`.