### PR TITLE
correct .env_deps for 2021.11.10 builds

### DIFF
--- a/saturn-geospatial/.env_deps
+++ b/saturn-geospatial/.env_deps
@@ -1,3 +1,3 @@
-VERSION=2021.07.26-0
-SATURNBASE_IMAGE=saturncloud/saturnbase:2021.02.22
-IMAGE=saturncloud/saturn-geospatial:2021.07.26-0
+VERSION=2021.11.10-1
+SATURNBASE_IMAGE=saturncloud/saturnbase:2021.11.10
+IMAGE=saturncloud/saturn-geospatial:2021.11.10-1

--- a/saturn-pytorch/.env_deps
+++ b/saturn-pytorch/.env_deps
@@ -1,3 +1,3 @@
-VERSION=2021.08.16
-SATURNBASE_GPU_IMAGE=saturncloud/saturnbase-gpu-11.2:2021.08.16-2
-IMAGE=saturncloud/saturn-pytorch:2021.08.16
+VERSION=2021.11.10-1
+SATURNBASE_GPU_IMAGE=saturncloud/saturnbase-gpu-11.2:2021.11.10
+IMAGE=saturncloud/saturn-pytorch:2021.11.10-1

--- a/saturn-r/.env_deps
+++ b/saturn-r/.env_deps
@@ -1,3 +1,3 @@
-VERSION=2021.11.10
+VERSION=2021.11.10-1
 SATURNBASE_IMAGE=saturncloud/saturnbase:2021.11.10
-IMAGE=saturncloud/saturn-r:2021.11.10
+IMAGE=saturncloud/saturn-r:2021.11.10-1

--- a/saturn-rapids/.env_deps
+++ b/saturn-rapids/.env_deps
@@ -1,3 +1,3 @@
-VERSION=2021.08.10-0
-SATURNBASE_GPU_IMAGE=saturnbase-gpu-11.2:2021.08.10-0
-IMAGE=saturncloud/saturn-rapids:2021.08.10-0
+VERSION=2021.11.10-1
+SATURNBASE_GPU_IMAGE=saturnbase-gpu-11.2:2021.11.10
+IMAGE=saturncloud/saturn-rapids:2021.11.10-1

--- a/saturn-rstudio/.env_deps
+++ b/saturn-rstudio/.env_deps
@@ -1,3 +1,3 @@
-VERSION=2021.10.26-1
-SATURN_R_IMAGE=saturncloud/saturn-r:2021.09.20
-IMAGE=saturncloud/saturn-rstudio:2021.10.26-1
+VERSION=2021.11.10-1
+SATURN_R_IMAGE=saturncloud/saturn-r:2021.11.10
+IMAGE=saturncloud/saturn-rstudio:2021.11.10-1

--- a/saturn-tensorflow/.env_deps
+++ b/saturn-tensorflow/.env_deps
@@ -1,3 +1,3 @@
-VERSION=2021.08.16
-SATURNBASE_GPU_IMAGE=saturncloud/saturnbase-gpu-11.2:2021.08.16-2
-IMAGE=saturncloud/saturn-tensorflow:2021.08.16
+VERSION=2021.11.10-1
+SATURNBASE_GPU_IMAGE=saturncloud/saturnbase-gpu-11.2:2021.11.10
+IMAGE=saturncloud/saturn-tensorflow:2021.11.10-1

--- a/saturn/.env_deps
+++ b/saturn/.env_deps
@@ -1,3 +1,3 @@
-VERSION=2021.07.26-0
-SATURNBASE_IMAGE=saturncloud/saturnbase:2021.02.22
-IMAGE=saturncloud/saturn:2021.07.26-0
+VERSION=2021.11.10-1
+SATURNBASE_IMAGE=saturncloud/saturnbase:2021.11.10
+IMAGE=saturncloud/saturn:2021.11.10-1


### PR DESCRIPTION
We have an ongoing automation issue that causes the updates to `.env_deps` for this repo to be spotty at best. This PR is a manual update to bring all of the `.env_deps` that were missed (some for multiple releases) to what they should currently be for the 2021.11.10 release.

(Note: `.env_deps` is only useful for local test builds. This PR's purpose to make sure those builds are as close to production builds as possible.)