### PR TITLE
Drop dask-labextension when using jlab3

### DIFF
--- a/saturnbase-gpu-10.1/environment.yml
+++ b/saturnbase-gpu-10.1/environment.yml
@@ -12,7 +12,6 @@ dependencies:
   - jupyter-server-proxy
   - dask-core
   - distributed
-  - dask-labextension
   - yarl
   - pyviz_comms
   - black

--- a/saturnbase-gpu-11.1/environment.yml
+++ b/saturnbase-gpu-11.1/environment.yml
@@ -12,7 +12,6 @@ dependencies:
   - jupyter-server-proxy
   - dask-core
   - distributed
-  - dask-labextension
   - yarl
   - pyviz_comms
   - black

--- a/saturnbase-gpu-11.2/environment.yml
+++ b/saturnbase-gpu-11.2/environment.yml
@@ -12,7 +12,6 @@ dependencies:
   - jupyter-server-proxy
   - dask-core
   - distributed
-  - dask-labextension
   - yarl
   - pyviz_comms
   - black

--- a/saturnbase/environment.yml
+++ b/saturnbase/environment.yml
@@ -12,7 +12,6 @@ dependencies:
   - jupyter-server-proxy
   - dask-core
   - distributed
-  - dask-labextension
   - yarl
   - pyviz_comms
   - black


### PR DESCRIPTION
Dask labextension does not quite work with SaturnCluster when using jlab3, so until we can get a change into upstream, we agreed to remove it from the images.