### PR TITLE
Base r updates

### DIFF
--- a/saturn-r/postBuild
+++ b/saturn-r/postBuild
@@ -27,13 +27,16 @@ sudo apt install -y \
     qpdf
 
 # Make all library folders readable then let R known
-RUN sudo chown 1000:1000 -R $R_LIBS \
-    && sudo chmod 777 -R $R_LIBS \
+RUN sudo mkdir -p /usr/local/lib/R \
+    && sudo mkdir -p /usr/local/lib/R/site-library \
+    && sudo mkdir -p /usr/lib/R/site-library \
+    && sudo mkdir -p /usr/lib/R/library \
     && sudo chown 1000:1000 -R /usr/local/lib/R \
     && sudo chmod 777 -R /usr/local/lib/R \
     && sudo chown 1000:1000 -R /usr/lib/R \
     && sudo chmod 777 -R /usr/lib/R \
     && sudo su -c "echo 'R_LIBS=/usr/local/lib/R:/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library' >> /usr/lib/R/etc/Renviron"
+
 
 # install other packages
 sudo Rscript -e "install.packages(c( \

--- a/saturn-r/postBuild
+++ b/saturn-r/postBuild
@@ -27,7 +27,7 @@ sudo apt install -y \
     qpdf
 
 # Make all library folders readable then let R known
-RUN sudo mkdir -p /usr/local/lib/R \
+sudo mkdir -p /usr/local/lib/R \
     && sudo mkdir -p /usr/local/lib/R/site-library \
     && sudo mkdir -p /usr/lib/R/site-library \
     && sudo mkdir -p /usr/lib/R/library \

--- a/saturn-r/postBuild
+++ b/saturn-r/postBuild
@@ -26,9 +26,14 @@ sudo apt install -y \
     libzmq3-dev \
     qpdf
 
-# make it possible to `install.packages()` - write permissions required.
-sudo chown 1000:1000 -R $R_LIBS
-sudo chmod 777 -R $R_LIBS
+# Make all library folders readable then let R known
+RUN sudo chown 1000:1000 -R $R_LIBS \
+    && sudo chmod 777 -R $R_LIBS \
+    && sudo chown 1000:1000 -R /usr/local/lib/R \
+    && sudo chmod 777 -R /usr/local/lib/R \
+    && sudo chown 1000:1000 -R /usr/lib/R \
+    && sudo chmod 777 -R /usr/lib/R \
+    && sudo su -c "echo 'R_LIBS=/usr/local/lib/R:/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library' >> /usr/lib/R/etc/Renviron"
 
 # install other packages
 sudo Rscript -e "install.packages(c( \
@@ -52,3 +57,6 @@ sudo Rscript -e "install.packages(c( \
 
 # Set up R kernel for Jupyter
 sudo Rscript -e "IRkernel::installspec(user = FALSE)"
+
+# Setup R reticulate for Python
+sudo su -c "echo 'RETICULATE_PYTHON=/opt/conda/envs/saturn/bin/python' >> /usr/lib/R/etc/Renviron"


### PR DESCRIPTION
This fixes two issues:

1. the reticulate package wasn't working because R couldn't find the Python install
2. The packages installed in the start script weren't in a location that RStudio user accounts know to look