### PR TITLE
Enable healthcheck for rstudio

### DIFF
--- a/saturn-rstudio/rserver.conf
+++ b/saturn-rstudio/rserver.conf
@@ -5,3 +5,4 @@ server-user=jovyan
 auth-none=1
 auth-validate-users=0
 www-port=8888
+server-health-check-enabled=1


### PR DESCRIPTION
Without this config entry, the healthcheck route is unavailable.
