### PR TITLE
Set ceiling for setuptools

### DIFF
--- a/examples-cpu/environment.yml
+++ b/examples-cpu/environment.yml
@@ -33,6 +33,7 @@ dependencies:
 - s3fs
 - scikit-learn
 - scipy
+- setuptools<60.0
 - voila
 - xgboost>=1.3.0
 - pip:

--- a/examples-gpu/environment.yml
+++ b/examples-gpu/environment.yml
@@ -24,6 +24,7 @@ dependencies:
 - s3fs
 - scikit-learn
 - scipy
+- setuptools<60.0
 - voila
 - xgboost=1.3.0dev.rapidsai0.17=cuda10.1py37_0
 - pip:

--- a/saturn-geospatial/environment.yml
+++ b/saturn-geospatial/environment.yml
@@ -29,6 +29,7 @@ dependencies:
 - rasterio
 - s3fs
 - scipy
+- setuptools<60.0
 - voila
 - xarray
 - zarr

--- a/saturn-pytorch/environment.yml
+++ b/saturn-pytorch/environment.yml
@@ -27,6 +27,7 @@ dependencies:
 - python-graphviz
 - pytorch=1.9.1=py3.9_cuda11.1_cudnn8.0.5_0
 - s3fs
+- setuptools<60.0
 - tensorboard
 - torchvision
 - pip:

--- a/saturn-r/environment.yml
+++ b/saturn-r/environment.yml
@@ -7,3 +7,4 @@ dependencies:
 - ipykernel
 - pip
 - python=3.7
+- setuptools<60.0

--- a/saturn-rapids/environment.yml
+++ b/saturn-rapids/environment.yml
@@ -28,6 +28,7 @@ dependencies:
 - s3fs
 - scikit-learn
 - scipy
+- setuptools<60.0
 - voila
 - xgboost=1.4.2dev.rapidsai21.06=cuda11.2py37_0
 - pip:

--- a/saturn-tensorflow/environment.yml
+++ b/saturn-tensorflow/environment.yml
@@ -22,6 +22,7 @@ dependencies:
 - python=3.9
 - python-graphviz
 - s3fs
+- setuptools<60.0
 - tensorboard
 - tensorflow-estimator
 - tensorflow=2.4.1=gpu_py39h8236f22_0

--- a/saturn/environment.yml
+++ b/saturn/environment.yml
@@ -21,6 +21,7 @@ dependencies:
 - s3fs
 - scikit-learn
 - scipy
+- setuptools<60.0
 - voila
 - xgboost>=1.3.0
 - pip:

--- a/saturnbase-gpu-10.1/environment.yml
+++ b/saturnbase-gpu-10.1/environment.yml
@@ -21,6 +21,7 @@ dependencies:
   - nbdime
   - voila
   - pip
+  - setuptools<60.0
   - pip:
     - nbclassic>=0.2.8
     - jupyterlab_execute_time

--- a/saturnbase-gpu-11.1/environment.yml
+++ b/saturnbase-gpu-11.1/environment.yml
@@ -21,6 +21,7 @@ dependencies:
   - nbdime
   - voila
   - pip
+  - setuptools<60.0
   - pip:
     - nbclassic>=0.2.8
     - jupyterlab_execute_time

--- a/saturnbase-gpu-11.2/environment.yml
+++ b/saturnbase-gpu-11.2/environment.yml
@@ -21,6 +21,7 @@ dependencies:
   - nbdime
   - voila
   - pip
+  - setuptools<60.0
   - pip:
     - nbclassic>=0.2.8
     - jupyterlab_execute_time

--- a/saturnbase/environment.yml
+++ b/saturnbase/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - nbdime
   - voila
   - pip
+  - setuptools<60.0
   - pip:
     - nbclassic>=0.2.8
     - jupyterlab_execute_time


### PR DESCRIPTION
In the latest setuptools release (60.0.3) all packages that user the version from distutils raise warnings on import. I'm setting a ceiling in all the envs to avoid this.
