### PR TITLE
Added R ODBC drivers (specifically Snowflake)

### DIFF
--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -79,6 +79,8 @@ RUN \
         ssh \
         sudo \
         wget \
+        unixodbc \
+        unixodbc-dev \
      > /dev/null \
     # CUDA fix
     && ln -s /usr/local/cuda-11.1/targets/x86_64-linux/lib/libcusolver.so.11 /usr/local/lib/libcusolver.so.10 \
@@ -145,6 +147,12 @@ ENV NB_PYTHON_PREFIX ${CONDA_DIR}/envs/saturn
 ENV PATH ${NB_PYTHON_PREFIX}/bin:${CONDA_BIN}:${NPM_DIR}/bin:${HOME}/.local/bin:${PATH}
 WORKDIR ${HOME}
 
+## Add Snowflake ODBC driver
+RUN && sudo apt-get install -f \
+    && wget https://sfc-repo.snowflakecomputing.com/odbc/linux/2.24.0/snowflake-odbc-2.24.0.x86_64.deb -O snowflake-odbc.deb \
+    && sudo dpkg -i snowflake-odbc.deb \
+    && sudo wget https://saturn-public-data.s3.us-east-2.amazonaws.com/r-odbc/odbc.ini -O /usr/lib/snowflake/odbc/lib/odbc.ini \
+    && sudo wget https://saturn-public-data.s3.us-east-2.amazonaws.com/r-odbc/odbcinst.ini -O /usr/lib/snowflake/odbc/lib/odbcinst.ini
 # Configure rstudio
 COPY --chown=root:root rstudio-start.sh /usr/local/bin/rstudio-start.sh
 RUN sudo chmod +x /usr/local/bin/rstudio-start.sh

--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -105,6 +105,12 @@ RUN \
         dependencies = c('LinkingTo', 'Depends', 'Imports'), \
         lib = '/usr/local/lib/R/site-library' \
         )" \
+    # add snowflake ODBC driver
+    && sudo apt-get install -f \
+    && wget https://sfc-repo.snowflakecomputing.com/odbc/linux/2.24.0/snowflake-odbc-2.24.0.x86_64.deb -O snowflake-odbc.deb \
+    && sudo dpkg -i snowflake-odbc.deb \
+    && sudo wget https://saturn-public-data.s3.us-east-2.amazonaws.com/r-odbc/odbc.ini -O /usr/lib/snowflake/odbc/lib/odbc.ini \
+    && sudo wget https://saturn-public-data.s3.us-east-2.amazonaws.com/r-odbc/odbcinst.ini -O /usr/lib/snowflake/odbc/lib/odbcinst.ini \
     # Cleanup
     && sudo rm -rf /tmp/* \
     && apt-get -qq purge \
@@ -147,12 +153,6 @@ ENV NB_PYTHON_PREFIX ${CONDA_DIR}/envs/saturn
 ENV PATH ${NB_PYTHON_PREFIX}/bin:${CONDA_BIN}:${NPM_DIR}/bin:${HOME}/.local/bin:${PATH}
 WORKDIR ${HOME}
 
-## Add Snowflake ODBC driver
-RUN sudo apt-get install -f \
-    && wget https://sfc-repo.snowflakecomputing.com/odbc/linux/2.24.0/snowflake-odbc-2.24.0.x86_64.deb -O snowflake-odbc.deb \
-    && sudo dpkg -i snowflake-odbc.deb \
-    && sudo wget https://saturn-public-data.s3.us-east-2.amazonaws.com/r-odbc/odbc.ini -O /usr/lib/snowflake/odbc/lib/odbc.ini \
-    && sudo wget https://saturn-public-data.s3.us-east-2.amazonaws.com/r-odbc/odbcinst.ini -O /usr/lib/snowflake/odbc/lib/odbcinst.ini
 # Configure rstudio
 COPY --chown=root:root rstudio-start.sh /usr/local/bin/rstudio-start.sh
 RUN sudo chmod +x /usr/local/bin/rstudio-start.sh

--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -148,7 +148,7 @@ ENV PATH ${NB_PYTHON_PREFIX}/bin:${CONDA_BIN}:${NPM_DIR}/bin:${HOME}/.local/bin:
 WORKDIR ${HOME}
 
 ## Add Snowflake ODBC driver
-RUN && sudo apt-get install -f \
+RUN sudo apt-get install -f \
     && wget https://sfc-repo.snowflakecomputing.com/odbc/linux/2.24.0/snowflake-odbc-2.24.0.x86_64.deb -O snowflake-odbc.deb \
     && sudo dpkg -i snowflake-odbc.deb \
     && sudo wget https://saturn-public-data.s3.us-east-2.amazonaws.com/r-odbc/odbc.ini -O /usr/lib/snowflake/odbc/lib/odbc.ini \

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -43,11 +43,12 @@ RUN apt-get -qq --allow-releaseinfo-change update && \
         libcurl4-openssl-dev \
         libssl1.1 \
         openssl \
-        libssl-dev \
         libuser \
         libuser1-dev \
         openssh-client \
         rrdtool \
+        unixodbc \
+        unixodbc-dev \
      > /dev/null && \
     apt-get -qq purge && \
     apt-get -qq clean && \
@@ -138,6 +139,13 @@ RUN sudo mkdir -p /usr/local/lib/R \
 ARG RSTUDIO_VERSION=2021.09.0-351
 
 ARG TINI_VERSION=0.18.0
+
+## Add Snowflake ODBC driver
+RUN sudo apt-get install -f \
+    && wget https://sfc-repo.snowflakecomputing.com/odbc/linux/2.24.0/snowflake-odbc-2.24.0.x86_64.deb -O snowflake-odbc.deb \
+    && sudo dpkg -i snowflake-odbc.deb \
+    && sudo wget https://saturn-public-data.s3.us-east-2.amazonaws.com/r-odbc/odbc.ini -O /usr/lib/snowflake/odbc/lib/odbc.ini \
+    && sudo wget https://saturn-public-data.s3.us-east-2.amazonaws.com/r-odbc/odbcinst.ini -O /usr/lib/snowflake/odbc/lib/odbcinst.ini
 
 # hadolint ignore=DL3008,DL3009
 RUN curl -o rstudio.deb https://download2.rstudio.org/server/bionic/amd64/rstudio-server-${RSTUDIO_VERSION}-amd64.deb \

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -50,6 +50,12 @@ RUN apt-get -qq --allow-releaseinfo-change update && \
         unixodbc \
         unixodbc-dev \
      > /dev/null && \
+    # add snowflake ODBC driver
+    && sudo apt-get install -f \
+    && wget https://sfc-repo.snowflakecomputing.com/odbc/linux/2.24.0/snowflake-odbc-2.24.0.x86_64.deb -O snowflake-odbc.deb \
+    && sudo dpkg -i snowflake-odbc.deb \
+    && sudo wget https://saturn-public-data.s3.us-east-2.amazonaws.com/r-odbc/odbc.ini -O /usr/lib/snowflake/odbc/lib/odbc.ini \
+    && sudo wget https://saturn-public-data.s3.us-east-2.amazonaws.com/r-odbc/odbcinst.ini -O /usr/lib/snowflake/odbc/lib/odbcinst.ini \
     apt-get -qq purge && \
     apt-get -qq clean && \
     rm -rf /var/lib/apt/lists/* && \
@@ -139,13 +145,6 @@ RUN sudo mkdir -p /usr/local/lib/R \
 ARG RSTUDIO_VERSION=2021.09.0-351
 
 ARG TINI_VERSION=0.18.0
-
-## Add Snowflake ODBC driver
-RUN sudo apt-get install -f \
-    && wget https://sfc-repo.snowflakecomputing.com/odbc/linux/2.24.0/snowflake-odbc-2.24.0.x86_64.deb -O snowflake-odbc.deb \
-    && sudo dpkg -i snowflake-odbc.deb \
-    && sudo wget https://saturn-public-data.s3.us-east-2.amazonaws.com/r-odbc/odbc.ini -O /usr/lib/snowflake/odbc/lib/odbc.ini \
-    && sudo wget https://saturn-public-data.s3.us-east-2.amazonaws.com/r-odbc/odbcinst.ini -O /usr/lib/snowflake/odbc/lib/odbcinst.ini
 
 # hadolint ignore=DL3008,DL3009
 RUN curl -o rstudio.deb https://download2.rstudio.org/server/bionic/amd64/rstudio-server-${RSTUDIO_VERSION}-amd64.deb \


### PR DESCRIPTION
This updates the RStudio images to include:

* The linux libraries for using ODBC drivers
* The Snowflake odbc driver specifically

This means our examples no longer need to install these.

Note that this only includes the actual *Snowflake* ODBC drivers, if users want to use a different system like MS SQL Server then they'll need to install those drivers themselves.

(cc @nathanballou )