### PR TITLE
Don't install R packages with sudo

### DIFF
--- a/saturn-rstudio-tensorflow/postBuild
+++ b/saturn-rstudio-tensorflow/postBuild
@@ -1,6 +1,6 @@
 
 # install other packages
-sudo Rscript -e "install.packages(c( \
+Rscript -e "install.packages(c( \
         'data.table', \
         'devtools', \
         'dplyr', \

--- a/saturn-rstudio/postBuild
+++ b/saturn-rstudio/postBuild
@@ -1,6 +1,6 @@
 
 # install other packages
-sudo Rscript -e "install.packages(c( \
+Rscript -e "install.packages(c( \
         'data.table', \
         'devtools', \
         'dplyr', \


### PR DESCRIPTION
Installing these packages with `sudo` causes subsequent installs (such as for `extra_packages`) to fail if they try to update one of the packages installed in this way, because this `sudo` usage results in the packages being owned by `root`.