### PR TITLE
manually update env_deps for release-2021.01.06

### DIFF
--- a/saturn-pytorch/.env_deps
+++ b/saturn-pytorch/.env_deps
@@ -1,3 +1,3 @@
-VERSION=2021.11.10-2
-SATURNBASE_GPU_IMAGE=saturncloud/saturnbase-gpu-11.2:2021.11.10
-IMAGE=saturncloud/saturn-pytorch:2021.11.10-2
+VERSION=2022.01.06-1
+SATURNBASE_GPU_IMAGE=saturncloud/saturnbase-gpu-11.2:2022.01.06
+IMAGE=saturncloud/saturn-pytorch:2022.01.06-1

--- a/saturn-pytorch/.env_deps
+++ b/saturn-pytorch/.env_deps
@@ -1,3 +1,3 @@
 VERSION=2022.01.06-1
-SATURNBASE_GPU_IMAGE=saturncloud/saturnbase-gpu-11.2:2022.01.06
-IMAGE=saturncloud/saturn-pytorch:2022.01.06-1
+SATURNBASE_GPU_IMAGE=public.ecr.aws/saturncloud/saturnbase-gpu-11.2:2022.01.06
+IMAGE=public.ecr.aws/saturncloud/saturn-pytorch:2022.01.06-1

--- a/saturn-rapids/.env_deps
+++ b/saturn-rapids/.env_deps
@@ -1,3 +1,3 @@
 VERSION=2022.01.06-1
 SATURNBASE_GPU_IMAGE=saturnbase-gpu-11.2:2022.01.06
-IMAGE=saturncloud/saturn-rapids:2022.01.06-1
+IMAGE=public.ecr.aws/saturncloud/saturn-rapids:2022.01.06-1

--- a/saturn-rapids/.env_deps
+++ b/saturn-rapids/.env_deps
@@ -1,3 +1,3 @@
-VERSION=2021.11.10-2
-SATURNBASE_GPU_IMAGE=saturnbase-gpu-11.2:2021.11.10
-IMAGE=saturncloud/saturn-rapids:2021.11.10-2
+VERSION=2022.01.06-1
+SATURNBASE_GPU_IMAGE=saturnbase-gpu-11.2:2022.01.06
+IMAGE=saturncloud/saturn-rapids:2022.01.06-1

--- a/saturn-rstudio-lite/.env_deps
+++ b/saturn-rstudio-lite/.env_deps
@@ -1,3 +1,3 @@
 VERSION=2021.11.10-2
-SATURNBASE_IMAGE=saturncloud/saturnbase:2021.11.10
-IMAGE=saturncloud/saturn-r:2021.11.10-2
+SATURNBASE_IMAGE=saturncloud/saturnbase-rstudio:2022.01.06
+IMAGE=saturncloud/saturn-rstudio-lite:2021.11.10-2

--- a/saturn-rstudio-lite/.env_deps
+++ b/saturn-rstudio-lite/.env_deps
@@ -1,3 +1,3 @@
 VERSION=2021.11.10-2
-SATURNBASE_IMAGE=saturncloud/saturnbase-rstudio:2022.01.06
-IMAGE=saturncloud/saturn-rstudio-lite:2021.11.10-2
+SATURNBASE_IMAGE=public.ecr.aws/saturncloud/saturnbase-rstudio:2022.01.06
+IMAGE=public.ecr.aws/saturncloud/saturn-rstudio-lite:2021.11.10-2

--- a/saturn-rstudio-tensorflow/.env_deps
+++ b/saturn-rstudio-tensorflow/.env_deps
@@ -1,3 +1,3 @@
-VERSION=2021.11.10-2
-SATURNBASE_GPU_IMAGE=saturncloud/saturnbase:2021.11.10
-IMAGE=saturncloud/saturn-r:2021.11.10-2
+VERSION=2022.01.06-1
+SATURNBASE_GPU_IMAGE=saturncloud/saturnbase-rstudio-gpu-11.1:2022.01.06
+IMAGE=saturncloud/saturn-rstudio-tensorflow:2022.01.06-1

--- a/saturn-rstudio-tensorflow/.env_deps
+++ b/saturn-rstudio-tensorflow/.env_deps
@@ -1,3 +1,3 @@
 VERSION=2022.01.06-1
-SATURNBASE_GPU_IMAGE=saturncloud/saturnbase-rstudio-gpu-11.1:2022.01.06
-IMAGE=saturncloud/saturn-rstudio-tensorflow:2022.01.06-1
+SATURNBASE_GPU_IMAGE=public.ecr.aws/saturncloud/saturnbase-rstudio-gpu-11.1:2022.01.06
+IMAGE=public.ecr.aws/saturncloud/saturn-rstudio-tensorflow:2022.01.06-1

--- a/saturn-rstudio/.env_deps
+++ b/saturn-rstudio/.env_deps
@@ -1,3 +1,3 @@
-VERSION=2021.11.10-2
-SATURNBASE_IMAGE=saturncloud/saturnbase:2021.11.10
-IMAGE=saturncloud/saturn-r:2021.11.10-2
+VERSION=2022.01.06-1
+SATURNBASE_IMAGE=saturncloud/saturnbase-rstudio:2022.01.06
+IMAGE=saturncloud/saturn-rstudio:2022.01.06-1

--- a/saturn-rstudio/.env_deps
+++ b/saturn-rstudio/.env_deps
@@ -1,3 +1,3 @@
 VERSION=2022.01.06-1
-SATURNBASE_IMAGE=saturncloud/saturnbase-rstudio:2022.01.06
-IMAGE=saturncloud/saturn-rstudio:2022.01.06-1
+SATURNBASE_IMAGE=public.ecr.aws/saturncloud/saturnbase-rstudio:2022.01.06
+IMAGE=public.ecr.aws/saturncloud/saturn-rstudio:2022.01.06-1

--- a/saturn-tensorflow/.env_deps
+++ b/saturn-tensorflow/.env_deps
@@ -1,3 +1,3 @@
 VERSION=2022.01.06-1
-SATURNBASE_GPU_IMAGE=saturncloud/saturnbase-gpu-11.2:2022.01.06
-IMAGE=saturncloud/saturn-tensorflow:2022.01.06-1
+SATURNBASE_GPU_IMAGE=public.ecr.aws/saturncloud/saturnbase-gpu-11.2:2022.01.06
+IMAGE=public.ecr.aws/saturncloud/saturn-tensorflow:2022.01.06-1

--- a/saturn-tensorflow/.env_deps
+++ b/saturn-tensorflow/.env_deps
@@ -1,3 +1,3 @@
-VERSION=2021.11.10-2
-SATURNBASE_GPU_IMAGE=saturncloud/saturnbase-gpu-11.2:2021.11.10
-IMAGE=saturncloud/saturn-tensorflow:2021.11.10-2
+VERSION=2022.01.06-1
+SATURNBASE_GPU_IMAGE=saturncloud/saturnbase-gpu-11.2:2022.01.06
+IMAGE=saturncloud/saturn-tensorflow:2022.01.06-1

--- a/saturn/.env_deps
+++ b/saturn/.env_deps
@@ -1,3 +1,3 @@
-VERSION=2021.11.10-2
-SATURNBASE_IMAGE=saturncloud/saturnbase:2021.11.10
-IMAGE=saturncloud/saturn:2021.11.10-2
+VERSION=2022.01.06-1
+SATURNBASE_IMAGE=saturncloud/saturnbase:2022.01.06
+IMAGE=saturncloud/saturn:2022.01.06-1

--- a/saturn/.env_deps
+++ b/saturn/.env_deps
@@ -1,3 +1,3 @@
 VERSION=2022.01.06-1
-SATURNBASE_IMAGE=saturncloud/saturnbase:2022.01.06
-IMAGE=saturncloud/saturn:2022.01.06-1
+SATURNBASE_IMAGE=public.ecr.aws/saturncloud/saturnbase:2022.01.06
+IMAGE=public.ecr.aws/saturncloud/saturn:2022.01.06-1

--- a/saturnbase-gpu-10.1/.env_deps
+++ b/saturnbase-gpu-10.1/.env_deps
@@ -1,2 +1,2 @@
 VERSION=2022.01.06-1
-IMAGE=saturncloud/saturnbase-gpu-10.1:2022.01.06-1
+IMAGE=public.ecr.aws/saturncloud/saturnbase-gpu-10.1:2022.01.06-1

--- a/saturnbase-gpu-10.1/.env_deps
+++ b/saturnbase-gpu-10.1/.env_deps
@@ -1,2 +1,2 @@
-VERSION=2021.11.10-2
-IMAGE=saturncloud/saturnbase-gpu-10.1:2021.11.10-2
+VERSION=2022.01.06-1
+IMAGE=saturncloud/saturnbase-gpu-10.1:2022.01.06-1

--- a/saturnbase-gpu-11.1/.env_deps
+++ b/saturnbase-gpu-11.1/.env_deps
@@ -1,2 +1,2 @@
-VERSION=2021.11.10-2
-IMAGE=saturncloud/saturnbase-gpu-11.1:2021.11.10-2
+VERSION=2022.01.06-1
+IMAGE=saturncloud/saturnbase-gpu-11.1:2022.01.06-1

--- a/saturnbase-gpu-11.1/.env_deps
+++ b/saturnbase-gpu-11.1/.env_deps
@@ -1,2 +1,2 @@
 VERSION=2022.01.06-1
-IMAGE=saturncloud/saturnbase-gpu-11.1:2022.01.06-1
+IMAGE=public.ecr.aws/saturncloud/saturnbase-gpu-11.1:2022.01.06-1

--- a/saturnbase-gpu-11.2/.env_deps
+++ b/saturnbase-gpu-11.2/.env_deps
@@ -1,2 +1,2 @@
-VERSION=2021.11.10-2
-IMAGE=saturncloud/saturnbase-gpu-11.2:2021.11.10-2
+VERSION=2022.01.06-1
+IMAGE=saturncloud/saturnbase-gpu-11.2:2022.01.06-1

--- a/saturnbase-gpu-11.2/.env_deps
+++ b/saturnbase-gpu-11.2/.env_deps
@@ -1,2 +1,2 @@
 VERSION=2022.01.06-1
-IMAGE=saturncloud/saturnbase-gpu-11.2:2022.01.06-1
+IMAGE=public.ecr.aws/saturncloud/saturnbase-gpu-11.2:2022.01.06-1

--- a/saturnbase-rstudio-gpu-11.1/.env_deps
+++ b/saturnbase-rstudio-gpu-11.1/.env_deps
@@ -1,2 +1,2 @@
 VERSION=2022.01.06-1
-IMAGE=saturncloud/saturnbase-rstudio-gpu-11.1:2022.01.06-1
+IMAGE=public.ecr.aws/saturncloud/saturnbase-rstudio-gpu-11.1:2022.01.06-1

--- a/saturnbase-rstudio-gpu-11.1/.env_deps
+++ b/saturnbase-rstudio-gpu-11.1/.env_deps
@@ -1,2 +1,2 @@
-VERSION=2021.11.10-2
-IMAGE=saturncloud/saturnbase-rstudio-gpu-11.1:2021.11.10-2
+VERSION=2022.01.06-1
+IMAGE=saturncloud/saturnbase-rstudio-gpu-11.1:2022.01.06-1

--- a/saturnbase-rstudio/.env_deps
+++ b/saturnbase-rstudio/.env_deps
@@ -1,2 +1,2 @@
 VERSION=2022.01.06-1
-IMAGE=saturncloud/saturnbase-rstudio:2022.01.06-1
+IMAGE=public.ecr.aws/saturncloud/saturnbase-rstudio:2022.01.06-1

--- a/saturnbase-rstudio/.env_deps
+++ b/saturnbase-rstudio/.env_deps
@@ -1,2 +1,2 @@
-VERSION=2021.11.10-4
-IMAGE=saturncloud/saturnbase-rstudio:2021.11.10-4
+VERSION=2022.01.06-1
+IMAGE=saturncloud/saturnbase-rstudio:2022.01.06-1

--- a/saturnbase/.env_deps
+++ b/saturnbase/.env_deps
@@ -1,2 +1,2 @@
 VERSION=2021.11.10-2
-IMAGE=saturncloud/saturnbase:2021.11.10-2
+IMAGE=public.ecr.aws/saturncloud/saturnbase:2021.11.10-2


### PR DESCRIPTION
Because the build process is not currently automatically bumping these for this repo, I've updated them manually so that all dependencies line up for local test builds.