### PR TITLE
`saturn-rstudio-torch`--a new R torch image

### DIFF
--- a/saturn-rstudio-torch/.dockerignore
+++ b/saturn-rstudio-torch/.dockerignore
@@ -1,0 +1,4 @@
+*
+!environment.yml
+!r-jupyter-kernel
+!postBuild

--- a/saturn-rstudio-torch/.env_deps
+++ b/saturn-rstudio-torch/.env_deps
@@ -1,0 +1,3 @@
+VERSION=2022.01.06-1
+SATURNBASE_GPU_IMAGE=public.ecr.aws/saturncloud/saturnbase-rstudio-gpu-11.1:2022.01.06
+IMAGE=public.ecr.aws/saturncloud/saturn-rstudio-torch:2022.01.06-1

--- a/saturn-rstudio-torch/Dockerfile
+++ b/saturn-rstudio-torch/Dockerfile
@@ -1,0 +1,17 @@
+
+ARG SATURNBASE_GPU_IMAGE
+FROM ${SATURNBASE_GPU_IMAGE}
+
+COPY environment.yml /tmp/environment.yml
+COPY postBuild /tmp/postBuild.sh
+
+# https://stat.ethz.ch/R-manual/R-devel/library/base/html/libPaths.html
+ENV R_LIBS=/usr/local/lib/R/
+
+RUN mamba env update -n saturn --file /tmp/environment.yml && \
+    find ${CONDA_DIR} -type f,l -name '*.pyc' -delete && \
+    find ${CONDA_DIR} -type f,l -name '*.a' -delete && \
+    find ${CONDA_DIR} -type f,l -name '*.js.map' -delete && \
+    /bin/bash -e -u -o pipefail /tmp/postBuild.sh && \
+    sudo rm /tmp/postBuild.sh && \
+    echo '' > ${CONDA_DIR}/envs/saturn/conda-meta/history

--- a/saturn-rstudio-torch/Makefile
+++ b/saturn-rstudio-torch/Makefile
@@ -1,0 +1,9 @@
+include .env_deps
+export
+
+build_image:
+	docker build \
+		--no-cache \
+		--build-arg SATURNBASE_IMAGE=${SATURNBASE_IMAGE} \
+		-t ${IMAGE} \
+		.

--- a/saturn-rstudio-torch/environment.yml
+++ b/saturn-rstudio-torch/environment.yml
@@ -1,0 +1,17 @@
+name: saturn
+channels:
+- nodefaults
+- conda-forge
+dependencies:
+- ipykernel
+- ipywidgets
+- matplotlib
+- numpy
+- pandas
+- pip
+- pyarrow
+- python-graphviz
+- s3fs
+- scikit-learn
+- scipy
+- python=3.8

--- a/saturn-rstudio-torch/postBuild
+++ b/saturn-rstudio-torch/postBuild
@@ -1,5 +1,5 @@
 # Set the cuda version for torch to use
-sudo su -c "echo 'CUDA=11.1' >> /usr/lib/R/etc/Renviron"
+sudo su -c "echo 'CUDA=11.1' >> /usr/local/lib/R/etc/Renviron"
 
 # install other packages
 Rscript -e "install.packages(c( \

--- a/saturn-rstudio-torch/postBuild
+++ b/saturn-rstudio-torch/postBuild
@@ -1,6 +1,11 @@
 # Set the cuda version for torch to use
 sudo su -c "echo 'CUDA=11.1' >> /usr/local/lib/R/etc/Renviron"
 
+# temporary fix for issue with renviron
+mkdir -p /usr/lib/R/etc \
+    && chown 1000:1000 -R /usr/lib/R \
+    && chmod 777 -R /usr/lib/R \
+
 # install other packages
 Rscript -e "install.packages(c( \
         'data.table', \

--- a/saturn-rstudio-torch/postBuild
+++ b/saturn-rstudio-torch/postBuild
@@ -1,0 +1,26 @@
+# Set the cuda version for torch to use
+sudo su -c "echo 'CUDA=11.1' >> /usr/lib/R/etc/Renviron"
+
+# install other packages
+Rscript -e "install.packages(c( \
+        'data.table', \
+        'devtools', \
+        'dplyr', \
+        'ggplot2', \
+        'lubridate', \
+        'Rcpp', \
+        'readr', \
+        'remotes', \
+        'reticulate', \
+        'stringr', \
+        'tidyr', \
+        'forcats', \
+        'tidyverse', \
+        'torch', \
+        'torchvision' \
+    ), Ncpus = max(c(1, parallel::detectCores() - 1)), \
+    dependencies = c('LinkingTo', 'Depends', 'Imports'), \
+    repos = 'https://packagemanager.rstudio.com/cran/__linux__/focal/latest' \
+    )"
+
+Rscript -e "torch::install_torch()"

--- a/saturn-rstudio-torch/postBuild
+++ b/saturn-rstudio-torch/postBuild
@@ -1,11 +1,6 @@
 # Set the cuda version for torch to use
 sudo su -c "echo 'CUDA=11.1' >> /usr/local/lib/R/etc/Renviron"
 
-# temporary fix for issue with renviron
-mkdir -p /usr/lib/R/etc \
-    && chown 1000:1000 -R /usr/lib/R \
-    && chmod 777 -R /usr/lib/R \
-
 # install other packages
 Rscript -e "install.packages(c( \
         'data.table', \


### PR DESCRIPTION
This adds `saturn-rstudio-torch` an image for RStudio GPU that supports torch instead of tensorflow. It's really big (like 8gb!) but I'm not sure how much we could get that down just because like torch for R itself is like 2 gigs