### PR TITLE
correct json for broken base images' recipe templates

### DIFF
--- a/saturnbase-rstudio-gpu-11.1/recipe-template.json
+++ b/saturnbase-rstudio-gpu-11.1/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "title": "saturnbase-rstudio-gpu-11.1",
+    "name": "saturnbase-rstudio-gpu-11.1",
     "description": "R-focused base image for Saturn RStudio GPU images, built on CUDA version 11.1 using rocker/ml (https://github.com/rocker-org/rocker-versioned2) as the starting point. The rocker/ml image is copyright of the rocker project. This image contains the packages necessary to run R, RStudio, and Python, and sets up environment variables for Reticulate support. Also installs a few libraries that are useful for Markdown support.",
     "hardware_type": "gpu",
     "supports": ["rstudio-opensource"]

--- a/saturnbase-rstudio-workbench-gpu-11.1/recipe-template.json
+++ b/saturnbase-rstudio-workbench-gpu-11.1/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "title": "saturnbase-rstudio-workbench-gpu-11.1",
+    "name": "saturnbase-rstudio-workbench-gpu-11.1",
     "description": "R-focused base image for Saturn RStudio Workbench GPU images, built on CUDA version 11.1 using rocker/ml (https://github.com/rocker-org/rocker-versioned2) as the starting point. The rocker/ml image is copyright of the rocker project. This image contains the packages necessary to run R, RStudio, and Python, and sets up environment variables for Reticulate support. Also installs a few libraries that are useful for Markdown support.",
     "hardware_type": "gpu",
     "supports": ["rstudio-workbench"]

--- a/saturnbase-rstudio-workbench/recipe-template.json
+++ b/saturnbase-rstudio-workbench/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "title": "saturnbase-rstudio-workbench",
+    "name": "saturnbase-rstudio-workbench",
     "description": "R-focused base image for Saturn RStudio images. This image contains the packages necessary to run R, RStudio, and Python and sets up environment variables for Reticulate support. Also installs a few libraries that are useful for Markdown support.",
     "hardware_type": "cpu",
     "supports": ["rstudio-workbench"]

--- a/saturnbase-rstudio/recipe-template.json
+++ b/saturnbase-rstudio/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "title": "saturnbase-rstudio",
+    "name": "saturnbase-rstudio",
     "description": "R-focused base image for Saturn RStudio images. This image contains the packages necessary to run R, RStudio, and Python and sets up environment variables for Reticulate support. Also installs a few libraries that are useful for Markdown support.",
     "hardware_type": "cpu",
     "supports": ["rstudio-opensource"]


### PR DESCRIPTION
I made this mistake while converting these templates, then copied it a few times.