### PR TITLE
Reduce base images' descriptions to fit inside 255-character limit

### DIFF
--- a/saturnbase-gpu-10.1/recipe-template.json
+++ b/saturnbase-gpu-10.1/recipe-template.json
@@ -1,6 +1,6 @@
 {
     "name": "saturnbase-gpu-10.1",
-    "description": "Python-focused base image for Saturn GPU images, built on CUDA version 10.1. This image contains the minimal install required for the full functionality of Saturn Cloud on a GPU instance, including the packages necessary to run Python, JupyterLab, and Dask.",
+    "description": "Python-focused base image for Saturn GPU images, built on CUDA version 10.1. This image contains the minimal install required for the full functionality of Saturn Cloud on a GPU instance, including packages necessary to run Python, JupyterLab, and Dask.",
     "hardware_type": "gpu",
     "supports": ["jupyterlab", "dask"]
 }

--- a/saturnbase-gpu-11.1/recipe-template.json
+++ b/saturnbase-gpu-11.1/recipe-template.json
@@ -1,6 +1,6 @@
 {
     "name": "saturnbase-gpu-11.1",
-    "description": "Python-focused base image for Saturn GPU images, built on CUDA version 11.1. This image contains the minimal install required for the full functionality of Saturn Cloud on a GPU instance, including the packages necessary to run Python, JupyterLab, and Dask.",
+    "description": "Python-focused base image for Saturn GPU images, built on CUDA version 11.1. This image contains the minimal install required for the full functionality of Saturn Cloud on a GPU instance, including packages necessary to run Python, JupyterLab, and Dask.",
     "hardware_type": "gpu",
     "supports": ["jupyterlab", "dask"]
 }

--- a/saturnbase-gpu-11.2/recipe-template.json
+++ b/saturnbase-gpu-11.2/recipe-template.json
@@ -1,6 +1,6 @@
 {
     "name": "saturnbase-gpu-11.2",
-    "description": "Python-focused base image for Saturn GPU images, built on CUDA version 11.2. This image contains the minimal install required for the full functionality of Saturn Cloud on a GPU instance, including the packages necessary to run Python, JupyterLab, and Dask.",
+    "description": "Python-focused base image for Saturn GPU images, built on CUDA version 11.2. This image contains the minimal install required for the full functionality of Saturn Cloud on a GPU instance, including packages necessary to run Python, JupyterLab, and Dask.",
     "hardware_type": "gpu",
     "supports": ["jupyterlab", "dask"]
 }

--- a/saturnbase-rstudio-gpu-11.1/recipe-template.json
+++ b/saturnbase-rstudio-gpu-11.1/recipe-template.json
@@ -1,6 +1,6 @@
 {
     "name": "saturnbase-rstudio-gpu-11.1",
-    "description": "R-focused base image for Saturn RStudio GPU images, built on CUDA version 11.1 using rocker/ml (https://github.com/rocker-org/rocker-versioned2) as the starting point. The rocker/ml image is copyright of the rocker project. This image contains the packages necessary to run R, RStudio, and Python, and sets up environment variables for Reticulate support. Also installs a few libraries that are useful for Markdown support.",
+    "description": "R-focused base image for Saturn RStudio GPU images, built on CUDA version 11.1 using rocker/ml (https://github.com/rocker-org/rocker-versioned2). This image contains the packages necessary to run R, RStudio, Python, and Reticulate.",
     "hardware_type": "gpu",
     "supports": ["rstudio-opensource"]
 }

--- a/saturnbase-rstudio-workbench-gpu-11.1/recipe-template.json
+++ b/saturnbase-rstudio-workbench-gpu-11.1/recipe-template.json
@@ -1,6 +1,6 @@
 {
     "name": "saturnbase-rstudio-workbench-gpu-11.1",
-    "description": "R-focused base image for Saturn RStudio Workbench GPU images, built on CUDA version 11.1 using rocker/ml (https://github.com/rocker-org/rocker-versioned2) as the starting point. The rocker/ml image is copyright of the rocker project. This image contains the packages necessary to run R, RStudio, and Python, and sets up environment variables for Reticulate support. Also installs a few libraries that are useful for Markdown support.",
+    "description": "R-focused base image for Saturn RStudio GPU images, built on CUDA version 11.1 using rocker/ml (https://github.com/rocker-org/rocker-versioned2). This image contains the packages necessary to run R, RStudio, Python, and Reticulate.",
     "hardware_type": "gpu",
     "supports": ["rstudio-workbench"]
 }


### PR DESCRIPTION
Saturn has a limit of 255 characters on image descriptions. Some of the base images' descriptions were a little longer - I've edited them down to fit. The only ones with substantive changes were the rstudio GPU bases (descriptions both identical).
