### PR TITLE
prefix all image names with saturncloud/

### DIFF
--- a/saturn-geospatial/recipe-template.json
+++ b/saturn-geospatial/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturn-geospatial",
+    "name": "saturncloud/saturn-geospatial",
     "description": "A Python image containing libraries specific to geospatial IO, analysis, and visualization. Generally used for CPU instances.",
     "hardware_type": "cpu",
     "supports": ["jupyterlab", "dask"]

--- a/saturn-pytorch/recipe-template.json
+++ b/saturn-pytorch/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturn-pytorch",
+    "name": "saturncloud/saturn-pytorch",
     "description": "For deep learning with PyTorch. Includes all requirements for using PyTorch on a GPU and with Dask.",
     "hardware_type": "gpu",
     "supports": ["jupyterlab", "dask"]

--- a/saturn-rapids/recipe-template.json
+++ b/saturn-rapids/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturn-rapids",
+    "name": "saturncloud/saturn-rapids",
     "description": "For GPU-based acceleration using the RAPIDS library.",
     "hardware_type": "gpu",
     "supports": ["jupyterlab", "dask"]

--- a/saturn-rstudio-parallel/recipe-template.json
+++ b/saturn-rstudio-parallel/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturn-rstudio-parallel",
+    "name": "saturncloud/saturn-rstudio-parallel",
     "description": "For running parallel computations in RStudio",
     "hardware_type": "cpu",
     "supports": [

--- a/saturn-rstudio-tensorflow/recipe-template.json
+++ b/saturn-rstudio-tensorflow/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturn-rstudio-tensorflow",
+    "name": "saturncloud/saturn-rstudio-tensorflow",
     "description": "For running TensorFlow on a GPU in RStudio.",
     "hardware_type": "gpu",
     "supports": ["rstudio-opensource"]

--- a/saturn-rstudio-torch/recipe-template.json
+++ b/saturn-rstudio-torch/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturn-rstudio-torch",
+    "name": "saturncloud/saturn-rstudio-torch",
     "description": "For running Torch on a GPU in RStudio.",
     "hardware_type": "gpu",
     "supports": ["rstudio-opensource"]

--- a/saturn-rstudio-workbench-parallel/recipe-template.json
+++ b/saturn-rstudio-workbench-parallel/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturn-rstudio-workbench-parallel",
+    "name": "saturncloud/saturn-rstudio-workbench-parallel",
     "description": "For running parallel computations in RStudio Workbench",
     "hardware_type": "cpu",
     "supports": [

--- a/saturn-rstudio-workbench-tensorflow/recipe-template.json
+++ b/saturn-rstudio-workbench-tensorflow/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturn-rstudio-tensorflow",
+    "name": "saturncloud/saturn-rstudio-tensorflow",
     "description": "For running TensorFlow on a GPU in RStudio.",
     "hardware_type": "gpu",
     "supports": ["rstudio-opensource"]

--- a/saturn-rstudio-workbench-torch/recipe-template.json
+++ b/saturn-rstudio-workbench-torch/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturn-rstudio-workbench-torch",
+    "name": "saturncloud/saturn-rstudio-workbench-torch",
     "description": "For running Torch on a GPU in RStudio Workbench.",
     "hardware_type": "gpu",
     "supports": ["rstudio-workbench"]

--- a/saturn-rstudio-workbench/recipe-template.json
+++ b/saturn-rstudio-workbench/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturn-rstudio-workbench",
+    "name": "saturncloud/saturn-rstudio-workbench",
     "description": "For basic analysis using R and RStudio Workbench.",
     "hardware_type": "cpu",
     "supports": ["rstudio-workbench"]

--- a/saturn-rstudio/recipe-template.json
+++ b/saturn-rstudio/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturn-rstudio",
+    "name": "saturncloud/saturn-rstudio",
     "description": "For basic analysis using R and RStudio.",
     "hardware_type": "cpu",
     "supports": ["rstudio-opensource"]

--- a/saturn-tensorflow/recipe-template.json
+++ b/saturn-tensorflow/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturn-tensorflow",
+    "name": "saturncloud/saturn-tensorflow",
     "description": "For deep learning with TensorFlow. Includes all requirements for using TensorFlow on a GPU.",
     "hardware_type": "gpu",
     "supports": ["jupyterlab", "dask"]

--- a/saturn/recipe-template.json
+++ b/saturn/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturn",
+    "name": "saturncloud/saturn",
     "description": "For basic Python data analysis, machine learning, and parallel processing with Dask.",
     "hardware_type": "cpu",
     "supports": ["jupyterlab", "dask"]

--- a/saturnbase-gpu-10.1/recipe-template.json
+++ b/saturnbase-gpu-10.1/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturnbase-gpu-10.1",
+    "name": "saturncloud/saturnbase-gpu-10.1",
     "description": "Python-focused base image for Saturn GPU images, built on CUDA version 10.1. This image contains the minimal install required for the full functionality of Saturn Cloud on a GPU instance, including packages necessary to run Python, JupyterLab, and Dask.",
     "hardware_type": "gpu",
     "supports": ["jupyterlab", "dask"]

--- a/saturnbase-gpu-11.1/recipe-template.json
+++ b/saturnbase-gpu-11.1/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturnbase-gpu-11.1",
+    "name": "saturncloud/saturnbase-gpu-11.1",
     "description": "Python-focused base image for Saturn GPU images, built on CUDA version 11.1. This image contains the minimal install required for the full functionality of Saturn Cloud on a GPU instance, including packages necessary to run Python, JupyterLab, and Dask.",
     "hardware_type": "gpu",
     "supports": ["jupyterlab", "dask"]

--- a/saturnbase-gpu-11.2/recipe-template.json
+++ b/saturnbase-gpu-11.2/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturnbase-gpu-11.2",
+    "name": "saturncloud/saturnbase-gpu-11.2",
     "description": "Python-focused base image for Saturn GPU images, built on CUDA version 11.2. This image contains the minimal install required for the full functionality of Saturn Cloud on a GPU instance, including packages necessary to run Python, JupyterLab, and Dask.",
     "hardware_type": "gpu",
     "supports": ["jupyterlab", "dask"]

--- a/saturnbase-rstudio-gpu-11.1/recipe-template.json
+++ b/saturnbase-rstudio-gpu-11.1/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturnbase-rstudio-gpu-11.1",
+    "name": "saturncloud/saturnbase-rstudio-gpu-11.1",
     "description": "R-focused base image for Saturn RStudio GPU images, built on CUDA version 11.1 using rocker/ml (https://github.com/rocker-org/rocker-versioned2). This image contains the packages necessary to run R, RStudio, Python, and Reticulate.",
     "hardware_type": "gpu",
     "supports": ["rstudio-opensource"]

--- a/saturnbase-rstudio-workbench-gpu-11.1/recipe-template.json
+++ b/saturnbase-rstudio-workbench-gpu-11.1/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturnbase-rstudio-workbench-gpu-11.1",
+    "name": "saturncloud/saturnbase-rstudio-workbench-gpu-11.1",
     "description": "R-focused base image for Saturn RStudio GPU images, built on CUDA version 11.1 using rocker/ml (https://github.com/rocker-org/rocker-versioned2). This image contains the packages necessary to run R, RStudio, Python, and Reticulate.",
     "hardware_type": "gpu",
     "supports": ["rstudio-workbench"]

--- a/saturnbase-rstudio-workbench/recipe-template.json
+++ b/saturnbase-rstudio-workbench/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturnbase-rstudio-workbench",
+    "name": "saturncloud/saturnbase-rstudio-workbench",
     "description": "R-focused base image for Saturn RStudio images. This image contains the packages necessary to run R, RStudio, and Python and sets up environment variables for Reticulate support. Also installs a few libraries that are useful for Markdown support.",
     "hardware_type": "cpu",
     "supports": ["rstudio-workbench"]

--- a/saturnbase-rstudio/recipe-template.json
+++ b/saturnbase-rstudio/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturnbase-rstudio",
+    "name": "saturncloud/saturnbase-rstudio",
     "description": "R-focused base image for Saturn RStudio images. This image contains the packages necessary to run R, RStudio, and Python and sets up environment variables for Reticulate support. Also installs a few libraries that are useful for Markdown support.",
     "hardware_type": "cpu",
     "supports": ["rstudio-opensource"]

--- a/saturnbase/recipe-template.json
+++ b/saturnbase/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturnbase",
+    "name": "saturncloud/saturnbase",
     "description": "Python-focused base image for Saturn CPU images. This image contains the minimal install required for the full functionality of Saturn Cloud, including the packages necessary to run Python, JupyterLab, and Dask.",
     "hardware_type": "cpu",
     "supports": ["jupyterlab", "dask"]


### PR DESCRIPTION
This PR causes all recipe-created images to have the same naming convention that Saturn has used historically.