### PR TITLE
Added hotfix for reticulate issue

### DIFF
--- a/saturn-rstudio-lite/Dockerfile
+++ b/saturn-rstudio-lite/Dockerfile
@@ -11,4 +11,5 @@ RUN mamba env update -n saturn --file /tmp/environment.yml && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete && \
     /bin/bash -e -u -o pipefail /tmp/postBuild.sh && \
     sudo rm /tmp/postBuild.sh && \
-    echo '' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+    echo '# cmd: /opt/conda/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+# history command is a hotfix for https://github.com/rstudio/reticulate/issues/1184

--- a/saturn-rstudio-tensorflow/Dockerfile
+++ b/saturn-rstudio-tensorflow/Dockerfile
@@ -14,4 +14,5 @@ RUN mamba env update -n saturn --file /tmp/environment.yml && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete && \
     /bin/bash -e -u -o pipefail /tmp/postBuild.sh && \
     sudo rm /tmp/postBuild.sh && \
-    echo '' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+    echo '# cmd: /opt/conda/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+# history command is a hotfix for https://github.com/rstudio/reticulate/issues/1184

--- a/saturn-rstudio-torch/Dockerfile
+++ b/saturn-rstudio-torch/Dockerfile
@@ -14,4 +14,5 @@ RUN mamba env update -n saturn --file /tmp/environment.yml && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete && \
     /bin/bash -e -u -o pipefail /tmp/postBuild.sh && \
     sudo rm /tmp/postBuild.sh && \
-    echo '' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+    echo '# cmd: /opt/conda/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+# history command is a hotfix for https://github.com/rstudio/reticulate/issues/1184

--- a/saturn-rstudio-workbench-tensorflow/Dockerfile
+++ b/saturn-rstudio-workbench-tensorflow/Dockerfile
@@ -14,4 +14,5 @@ RUN mamba env update -n saturn --file /tmp/environment.yml && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete && \
     /bin/bash -e -u -o pipefail /tmp/postBuild.sh && \
     sudo rm /tmp/postBuild.sh && \
-    echo '' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+    echo '# cmd: /opt/conda/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+# history command is a hotfix for https://github.com/rstudio/reticulate/issues/1184

--- a/saturn-rstudio-workbench-torch/Dockerfile
+++ b/saturn-rstudio-workbench-torch/Dockerfile
@@ -14,4 +14,5 @@ RUN mamba env update -n saturn --file /tmp/environment.yml && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete && \
     /bin/bash -e -u -o pipefail /tmp/postBuild.sh && \
     sudo rm /tmp/postBuild.sh && \
-    echo '' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+    echo '# cmd: /opt/conda/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+# history command is a hotfix for https://github.com/rstudio/reticulate/issues/1184

--- a/saturn-rstudio-workbench/Dockerfile
+++ b/saturn-rstudio-workbench/Dockerfile
@@ -11,4 +11,5 @@ RUN mamba env update -n saturn --file /tmp/environment.yml && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete && \
     /bin/bash -e -u -o pipefail /tmp/postBuild.sh && \
     sudo rm /tmp/postBuild.sh && \
-    echo '' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+    echo '# cmd: /opt/conda/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+# history command is a hotfix for https://github.com/rstudio/reticulate/issues/1184

--- a/saturn-rstudio/Dockerfile
+++ b/saturn-rstudio/Dockerfile
@@ -11,4 +11,5 @@ RUN mamba env update -n saturn --file /tmp/environment.yml && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete && \
     /bin/bash -e -u -o pipefail /tmp/postBuild.sh && \
     sudo rm /tmp/postBuild.sh && \
-    echo '' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+    echo '# cmd: /opt/conda/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+# history command is a hotfix for https://github.com/rstudio/reticulate/issues/1184


### PR DESCRIPTION
Due to an issue in an R package used by some of our images, I needed to add a comment line to the conda history. This will likely be able to be removed at some point in the future.

https://github.com/rstudio/reticulate/issues/1184

I have tested that editing the file at startup fixes it so I think this change should do it, but I haven't technically tested editing it as part of the build process.