### PR TITLE
Set ceilings for click on all images that use distributed

### DIFF
--- a/saturn-pytorch/environment.yml
+++ b/saturn-pytorch/environment.yml
@@ -8,6 +8,7 @@ channels:
 dependencies:
 - blas=*=mkl
 - bokeh
+- click>=7.1.2,<8.0.0
 - dask=2021.07
 - distributed=2021.07
 - dask-cuda=21.8

--- a/saturn-rapids/environment.yml
+++ b/saturn-rapids/environment.yml
@@ -8,6 +8,7 @@ dependencies:
 - blas=*=mkl
 - blazingsql=21.06.00=cuda_11.2_py37_g95ff589f8_0
 - bokeh
+- click>=7.1.2,<8.0.0
 - cvxpy
 - dask-ml
 - dask=2021.4.1

--- a/saturn-tensorflow/environment.yml
+++ b/saturn-tensorflow/environment.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
 - blas=*=mkl
 - bokeh
+- click>=7.1.2,<8.0.0
 - dask=2021.07
 - distributed=2021.07
 - dask-cuda==21.8

--- a/saturn/environment.yml
+++ b/saturn/environment.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
 - blas=*=mkl
 - bokeh
+- click>=7.1.2,<8.0.0
 - dask-ml
 - dask=2021.07
 - distributed=2021.07

--- a/saturnbase-gpu-10.1/environment.yml
+++ b/saturnbase-gpu-10.1/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - jupyter-server-proxy
   - dask-core
   - distributed
+  - click>=7.1.2,<8.0.0
   - yarl
   - pyviz_comms
   - black

--- a/saturnbase-gpu-11.1/environment.yml
+++ b/saturnbase-gpu-11.1/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - jupyter-server-proxy
   - dask-core
   - distributed
+  - click>=7.1.2,<8.0.0
   - yarl
   - pyviz_comms
   - black

--- a/saturnbase-gpu-11.2/environment.yml
+++ b/saturnbase-gpu-11.2/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - jupyter-server-proxy
   - dask-core
   - distributed
+  - click>=7.1.2,<8.0.0
   - yarl
   - pyviz_comms
   - black

--- a/saturnbase/environment.yml
+++ b/saturnbase/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - jupyter-server-proxy
   - dask-core
   - distributed
+  - click>=7.1.2,<8.0.0
   - yarl
   - pyviz_comms
   - black


### PR DESCRIPTION
This resolves the issues we're seeing from the latest builds. This is resolved in https://github.com/dask/distributed/issues/6013, so we can remove these ceilings in each image once we update to a `distributed` release that includes that fix.

To test locally (on images where distributed is pinned to `2021.07`):

```python
from distributed.cli import utils
utils.check_python_3()
```