### PR TITLE
add 'conda clean' to rstudio torch builds

### DIFF
--- a/saturn-rstudio-torch/Dockerfile
+++ b/saturn-rstudio-torch/Dockerfile
@@ -9,6 +9,7 @@ COPY postBuild /tmp/postBuild.sh
 ENV R_LIBS=/usr/local/lib/R/
 
 RUN mamba env update -n saturn --file /tmp/environment.yml && \
+    conda clean -afy && \
     find ${CONDA_DIR} -type f,l -name '*.pyc' -delete && \
     find ${CONDA_DIR} -type f,l -name '*.a' -delete && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete && \

--- a/saturn-rstudio-workbench-torch/Dockerfile
+++ b/saturn-rstudio-workbench-torch/Dockerfile
@@ -9,6 +9,7 @@ COPY postBuild /tmp/postBuild.sh
 ENV R_LIBS=/usr/local/lib/R/
 
 RUN mamba env update -n saturn --file /tmp/environment.yml && \
+    conda clean -afy && \
     find ${CONDA_DIR} -type f,l -name '*.pyc' -delete && \
     find ${CONDA_DIR} -type f,l -name '*.a' -delete && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete && \


### PR DESCRIPTION
These two builds are pretty consistently running out of space in CI - other builds have this step, but these two do not. Worst case, this doesn't solve the issue - but shouldn't hurt anything.