### PR TITLE
correct md5sums for conda installer, update missed images

### DIFF
--- a/saturn-geospatial/environment.yml
+++ b/saturn-geospatial/environment.yml
@@ -24,7 +24,7 @@ dependencies:
 - pip
 - prefect
 - pyarrow
-- python=3.7
+- python=3.8
 - python-graphviz
 - rasterio
 - s3fs

--- a/saturn-rstudio-bioconductor/environment.yml
+++ b/saturn-rstudio-bioconductor/environment.yml
@@ -6,5 +6,5 @@ dependencies:
 - blas=*=mkl
 - ipykernel
 - pip
-- python=3.7
+- python=3.8
 - setuptools<60.0

--- a/saturn-rstudio-lite/environment.yml
+++ b/saturn-rstudio-lite/environment.yml
@@ -6,4 +6,4 @@ dependencies:
 - blas=*=mkl
 - ipykernel
 - pip
-- python=3.7
+- python=3.8

--- a/saturn-rstudio-workbench/environment.yml
+++ b/saturn-rstudio-workbench/environment.yml
@@ -6,5 +6,5 @@ dependencies:
 - blas=*=mkl
 - ipykernel
 - pip
-- python=3.7
+- python=3.8
 - setuptools<60.0

--- a/saturn-rstudio/environment.yml
+++ b/saturn-rstudio/environment.yml
@@ -6,5 +6,5 @@ dependencies:
 - blas=*=mkl
 - ipykernel
 - pip
-- python=3.7
+- python=3.8
 - setuptools<60.0

--- a/saturnbase-gpu-10.1/install-miniconda.bash
+++ b/saturnbase-gpu-10.1/install-miniconda.bash
@@ -10,7 +10,7 @@ INSTALLER_PATH=/tmp/miniconda-installer.sh
 wget --quiet $URL -O ${INSTALLER_PATH}
 chmod +x ${INSTALLER_PATH}
 
-MD5SUM="3143b1116f2d466d9325c206b7de88f7"
+MD5SUM="122c8c9beb51e124ab32a0fa6426c656"
 
 if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
     echo "md5sum mismatch for ${INSTALLER_PATH}, exiting!"

--- a/saturnbase-gpu-11.1/install-miniconda.bash
+++ b/saturnbase-gpu-11.1/install-miniconda.bash
@@ -10,7 +10,7 @@ INSTALLER_PATH=/tmp/miniconda-installer.sh
 wget --quiet $URL -O ${INSTALLER_PATH}
 chmod +x ${INSTALLER_PATH}
 
-MD5SUM="3143b1116f2d466d9325c206b7de88f7"
+MD5SUM="122c8c9beb51e124ab32a0fa6426c656"
 
 if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
     echo "md5sum mismatch for ${INSTALLER_PATH}, exiting!"

--- a/saturnbase-gpu-11.2/install-miniconda.bash
+++ b/saturnbase-gpu-11.2/install-miniconda.bash
@@ -10,7 +10,7 @@ INSTALLER_PATH=/tmp/miniconda-installer.sh
 wget --quiet $URL -O ${INSTALLER_PATH}
 chmod +x ${INSTALLER_PATH}
 
-MD5SUM="3143b1116f2d466d9325c206b7de88f7"
+MD5SUM="122c8c9beb51e124ab32a0fa6426c656"
 
 if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
     echo "md5sum mismatch for ${INSTALLER_PATH}, exiting!"

--- a/saturnbase-julia-gpu-11.3/install-miniconda.bash
+++ b/saturnbase-julia-gpu-11.3/install-miniconda.bash
@@ -4,13 +4,13 @@ set -ex
 
 cd $(dirname $0)
 
-MINICONDA_VERSION=py37_4.9.2
+MINICONDA_VERSION=py38_4.9.2
 URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
 INSTALLER_PATH=/tmp/miniconda-installer.sh
 wget --quiet $URL -O ${INSTALLER_PATH}
 chmod +x ${INSTALLER_PATH}
 
-MD5SUM="3143b1116f2d466d9325c206b7de88f7"
+MD5SUM="122c8c9beb51e124ab32a0fa6426c656"
 
 if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
     echo "md5sum mismatch for ${INSTALLER_PATH}, exiting!"

--- a/saturnbase-rstudio-bioconductor/install-miniconda.bash
+++ b/saturnbase-rstudio-bioconductor/install-miniconda.bash
@@ -4,13 +4,13 @@ set -ex
 
 cd $(dirname $0)
 
-MINICONDA_VERSION=py37_4.9.2
+MINICONDA_VERSION=py38_4.9.2
 URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
 INSTALLER_PATH=/tmp/miniconda-installer.sh
 wget --quiet $URL -O ${INSTALLER_PATH}
 chmod +x ${INSTALLER_PATH}
 
-MD5SUM="3143b1116f2d466d9325c206b7de88f7"
+MD5SUM="122c8c9beb51e124ab32a0fa6426c656"
 
 if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
     echo "md5sum mismatch for ${INSTALLER_PATH}, exiting!"

--- a/saturnbase-rstudio-gpu-11.1/install-miniconda.bash
+++ b/saturnbase-rstudio-gpu-11.1/install-miniconda.bash
@@ -10,7 +10,7 @@ INSTALLER_PATH=/tmp/miniconda-installer.sh
 wget --quiet $URL -O ${INSTALLER_PATH}
 chmod +x ${INSTALLER_PATH}
 
-MD5SUM="3143b1116f2d466d9325c206b7de88f7"
+MD5SUM="122c8c9beb51e124ab32a0fa6426c656"
 
 if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
     echo "md5sum mismatch for ${INSTALLER_PATH}, exiting!"

--- a/saturnbase-rstudio-workbench-gpu-11.1/install-miniconda.bash
+++ b/saturnbase-rstudio-workbench-gpu-11.1/install-miniconda.bash
@@ -10,7 +10,7 @@ INSTALLER_PATH=/tmp/miniconda-installer.sh
 wget --quiet $URL -O ${INSTALLER_PATH}
 chmod +x ${INSTALLER_PATH}
 
-MD5SUM="3143b1116f2d466d9325c206b7de88f7"
+MD5SUM="122c8c9beb51e124ab32a0fa6426c656"
 
 if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
     echo "md5sum mismatch for ${INSTALLER_PATH}, exiting!"


### PR DESCRIPTION
This corrects the md5sum after #323 and also updates the missed images to python 3.8.