### PR TITLE
Add libnuma-dev to deps for python gpu bases

### DIFF
--- a/saturnbase-gpu-10.1/Dockerfile
+++ b/saturnbase-gpu-10.1/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get -qq --allow-releaseinfo-change update && \
         htop \
         screen \
         build-essential \
+        libnuma-dev \
      > /dev/null && \
     apt-get -qq purge && \
     apt-get -qq clean && \

--- a/saturnbase-gpu-11.1/Dockerfile
+++ b/saturnbase-gpu-11.1/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get -qq --allow-releaseinfo-change update && \
         htop \
         screen \
         build-essential \
+        libnuma-dev \
      > /dev/null && \
     apt-get -qq purge && \
     apt-get -qq clean && \

--- a/saturnbase-gpu-11.2/Dockerfile
+++ b/saturnbase-gpu-11.2/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get -qq update && \
         htop \
         screen \
         build-essential \
+        libnuma-dev \
      > /dev/null && \
     apt-get -qq purge && \
     apt-get -qq clean && \


### PR DESCRIPTION
On our latest rapids images, `cuml` imports fail because of a transient dependency on `rapidsai/ucx-py` (https://github.com/rapidsai/cuml/issues/4616), which now requires `libnuma` but does not include it in the conda recipe (https://github.com/rapidsai/ucx-py/issues/790).

This PR adds `libnuma-dev` to the python GPU base images so that any `rapids` installs on top of them will work.