### PR TITLE
Pin pyarrow in DS images

### DIFF
--- a/saturn-geospatial/environment.yml
+++ b/saturn-geospatial/environment.yml
@@ -23,7 +23,7 @@ dependencies:
 - pandas
 - pip
 - prefect
-- pyarrow
+- pyarrow<6.1.0,>=6.0.0
 - python=3.8
 - python-graphviz
 - rasterio
@@ -34,6 +34,6 @@ dependencies:
 - xarray
 - zarr
 - pip:
-  - dask-saturn>=0.4.0
-  - prefect-saturn>=0.5.1
+  - dask-saturn>=0.4.1
+  - prefect-saturn>=0.6.0
   - snowflake-connector-python

--- a/saturn-pytorch/environment.yml
+++ b/saturn-pytorch/environment.yml
@@ -30,6 +30,6 @@ dependencies:
 - tensorboard
 - torchvision
 - pip:
-  - dask-saturn>=0.4.0
-  - prefect-saturn>=0.5.1
+  - dask-saturn>=0.4.1
+  - prefect-saturn>=0.6.0
   - snowflake-connector-python

--- a/saturn-rapids/environment.yml
+++ b/saturn-rapids/environment.yml
@@ -31,6 +31,6 @@ dependencies:
 - voila
 - xgboost=1.4.2dev.rapidsai21.10=cuda11.2py38_0
 - pip:
-  - dask-saturn>=0.4.0
-  - prefect-saturn>=0.5.1
+  - dask-saturn>=0.4.1
+  - prefect-saturn>=0.6.0
   - snowflake-connector-python

--- a/saturn-tensorflow/environment.yml
+++ b/saturn-tensorflow/environment.yml
@@ -17,7 +17,7 @@ dependencies:
 - pandas
 - pip
 - prefect
-- pyarrow
+- pyarrow<6.1.0,>=6.0.0
 - python=3.9
 - python-graphviz
 - s3fs
@@ -27,6 +27,6 @@ dependencies:
 - tensorflow=2.4.1=gpu_py39h8236f22_0
 - voila
 - pip:
-  - dask-saturn>=0.4.0
-  - prefect-saturn>=0.5.1
+  - dask-saturn>=0.4.2
+  - prefect-saturn>=0.6.0
   - snowflake-connector-python

--- a/saturn-tensorflow/environment.yml
+++ b/saturn-tensorflow/environment.yml
@@ -27,6 +27,6 @@ dependencies:
 - tensorflow=2.4.1=gpu_py39h8236f22_0
 - voila
 - pip:
-  - dask-saturn>=0.4.2
+  - dask-saturn>=0.4.1
   - prefect-saturn>=0.6.0
   - snowflake-connector-python

--- a/saturn/environment.yml
+++ b/saturn/environment.yml
@@ -14,7 +14,7 @@ dependencies:
 - pandas
 - pip
 - prefect
-- pyarrow
+- pyarrow<6.1.0,>=6.0.0
 - python
 - python-graphviz
 - s3fs
@@ -24,6 +24,6 @@ dependencies:
 - voila
 - xgboost>=1.3.0
 - pip:
-  - dask-saturn>=0.4.0
-  - prefect-saturn>=0.5.1
+  - dask-saturn>=0.4.1
+  - prefect-saturn>=0.6.0
   - snowflake-connector-python


### PR DESCRIPTION
Pins the pyarrow library in most DS images to avoid the warning message from snowflake-connector. Couldn't get a solve for PyTorch or RAPIDS, so we will have to investigate those further or provide an explanation in the docs. 

This also increases the required dask-saturn and prefect-saturn to avoid errors with new editions of Dask.
