### PR TITLE
Move /opt/conda to /opt/saturncloud

### DIFF
--- a/saturn-rstudio-bioconductor/Dockerfile
+++ b/saturn-rstudio-bioconductor/Dockerfile
@@ -11,5 +11,5 @@ RUN mamba env update -n saturn --file /tmp/environment.yml && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete && \
     /bin/bash -e -u -o pipefail /tmp/postBuild.sh && \
     sudo rm /tmp/postBuild.sh && \
-    echo '# cmd: /opt/conda/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+    echo '# cmd: /opt/saturncloud/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
 # history command is a hotfix for https://github.com/rstudio/reticulate/issues/1184

--- a/saturn-rstudio-lite/Dockerfile
+++ b/saturn-rstudio-lite/Dockerfile
@@ -11,5 +11,5 @@ RUN mamba env update -n saturn --file /tmp/environment.yml && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete && \
     /bin/bash -e -u -o pipefail /tmp/postBuild.sh && \
     sudo rm /tmp/postBuild.sh && \
-    echo '# cmd: /opt/conda/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+    echo '# cmd: /opt/saturncloud/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
 # history command is a hotfix for https://github.com/rstudio/reticulate/issues/1184

--- a/saturn-rstudio-tensorflow/Dockerfile
+++ b/saturn-rstudio-tensorflow/Dockerfile
@@ -14,5 +14,5 @@ RUN mamba env update -n saturn --file /tmp/environment.yml && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete && \
     /bin/bash -e -u -o pipefail /tmp/postBuild.sh && \
     sudo rm /tmp/postBuild.sh && \
-    echo '# cmd: /opt/conda/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+    echo '# cmd: /opt/saturncloud/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
 # history command is a hotfix for https://github.com/rstudio/reticulate/issues/1184

--- a/saturn-rstudio-torch/Dockerfile
+++ b/saturn-rstudio-torch/Dockerfile
@@ -15,5 +15,5 @@ RUN mamba env update -n saturn --file /tmp/environment.yml && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete && \
     /bin/bash -e -u -o pipefail /tmp/postBuild.sh && \
     sudo rm /tmp/postBuild.sh && \
-    echo '# cmd: /opt/conda/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+    echo '# cmd: /opt/saturncloud/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
 # history command is a hotfix for https://github.com/rstudio/reticulate/issues/1184

--- a/saturn-rstudio-workbench-tensorflow/Dockerfile
+++ b/saturn-rstudio-workbench-tensorflow/Dockerfile
@@ -14,5 +14,5 @@ RUN mamba env update -n saturn --file /tmp/environment.yml && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete && \
     /bin/bash -e -u -o pipefail /tmp/postBuild.sh && \
     sudo rm /tmp/postBuild.sh && \
-    echo '# cmd: /opt/conda/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+    echo '# cmd: /opt/saturncloud/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
 # history command is a hotfix for https://github.com/rstudio/reticulate/issues/1184

--- a/saturn-rstudio-workbench-torch/Dockerfile
+++ b/saturn-rstudio-workbench-torch/Dockerfile
@@ -15,5 +15,5 @@ RUN mamba env update -n saturn --file /tmp/environment.yml && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete && \
     /bin/bash -e -u -o pipefail /tmp/postBuild.sh && \
     sudo rm /tmp/postBuild.sh && \
-    echo '# cmd: /opt/conda/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+    echo '# cmd: /opt/saturncloud/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
 # history command is a hotfix for https://github.com/rstudio/reticulate/issues/1184

--- a/saturn-rstudio-workbench/Dockerfile
+++ b/saturn-rstudio-workbench/Dockerfile
@@ -11,5 +11,5 @@ RUN mamba env update -n saturn --file /tmp/environment.yml && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete && \
     /bin/bash -e -u -o pipefail /tmp/postBuild.sh && \
     sudo rm /tmp/postBuild.sh && \
-    echo '# cmd: /opt/conda/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+    echo '# cmd: /opt/saturncloud/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
 # history command is a hotfix for https://github.com/rstudio/reticulate/issues/1184

--- a/saturn-rstudio/Dockerfile
+++ b/saturn-rstudio/Dockerfile
@@ -11,5 +11,5 @@ RUN mamba env update -n saturn --file /tmp/environment.yml && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete && \
     /bin/bash -e -u -o pipefail /tmp/postBuild.sh && \
     sudo rm /tmp/postBuild.sh && \
-    echo '# cmd: /opt/conda/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+    echo '# cmd: /opt/saturncloud/bin/conda install papermill' > ${CONDA_DIR}/envs/saturn/conda-meta/history
 # history command is a hotfix for https://github.com/rstudio/reticulate/issues/1184

--- a/saturnbase-gpu-10.1/Dockerfile
+++ b/saturnbase-gpu-10.1/Dockerfile
@@ -1,8 +1,8 @@
 FROM nvidia/cuda:10.1-runtime-ubuntu18.04
 EXPOSE 8888
 
-RUN mkdir /opt/conda && \
-    ln -s /opt/conda /srv/conda
+RUN mkdir /opt/saturncloud && \
+    ln -s /opt/saturncloud /srv/conda
 ENV APP_BASE=/srv
 ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin
@@ -51,7 +51,7 @@ RUN adduser --disabled-password \
     ${NB_USER} && \
     echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook && \
     mkdir -p ${APP_BASE} && \
-    chown 1000:1000 -R /opt/conda && \
+    chown 1000:1000 -R /opt/saturncloud && \
     chown -R $NB_USER:$NB_USER ${APP_BASE}
 USER ${NB_USER}
 

--- a/saturnbase-gpu-11.1/Dockerfile
+++ b/saturnbase-gpu-11.1/Dockerfile
@@ -5,8 +5,8 @@ ARG JUPYTER_SATURN_VERSION
 
 ENV JUPYTER_SATURN_VERSION=${JUPYTER_SATURN_VERSION}
 
-RUN mkdir /opt/conda && \
-    ln -s /opt/conda /srv/conda
+RUN mkdir /opt/saturncloud && \
+    ln -s /opt/saturncloud /srv/conda
 ENV APP_BASE=/srv
 ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin
@@ -55,7 +55,7 @@ RUN adduser --disabled-password \
     ${NB_USER} && \
     echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook && \
     mkdir -p ${APP_BASE} && \
-    chown 1000:1000 -R /opt/conda && \
+    chown 1000:1000 -R /opt/saturncloud && \
     chown -R $NB_USER:$NB_USER ${APP_BASE}
 USER ${NB_USER}
 

--- a/saturnbase-gpu-11.2/Dockerfile
+++ b/saturnbase-gpu-11.2/Dockerfile
@@ -1,8 +1,8 @@
 FROM nvidia/cuda:11.2.1-runtime-ubuntu18.04
 EXPOSE 8888
 
-RUN mkdir /opt/conda && \
-    ln -s /opt/conda /srv/conda
+RUN mkdir /opt/saturncloud && \
+    ln -s /opt/saturncloud /srv/conda
 ENV APP_BASE=/srv
 ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin
@@ -51,7 +51,7 @@ RUN adduser --disabled-password \
     ${NB_USER} && \
     echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook && \
     mkdir -p ${APP_BASE} && \
-    chown 1000:1000 -R /opt/conda && \
+    chown 1000:1000 -R /opt/saturncloud && \
     chown -R $NB_USER:$NB_USER ${APP_BASE}
 USER ${NB_USER}
 

--- a/saturnbase-julia-gpu-11.3/Dockerfile
+++ b/saturnbase-julia-gpu-11.3/Dockerfile
@@ -3,8 +3,8 @@ EXPOSE 8888
 
 ENV JULIA_VERSION=1.7.2
 
-RUN mkdir /opt/conda && \
-    ln -s /opt/conda /srv/conda
+RUN mkdir /opt/saturncloud && \
+    ln -s /opt/saturncloud /srv/conda
 
 ENV APP_BASE=/srv
 ENV CONDA_DIR=/srv/conda
@@ -65,7 +65,7 @@ RUN adduser --disabled-password \
     ${NB_USER} && \
     echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook && \
     mkdir -p ${APP_BASE} && \
-    chown 1000:1000 -R /opt/conda && \
+    chown 1000:1000 -R /opt/saturncloud && \
     chown -R $NB_USER:$NB_USER ${APP_BASE}
 USER ${NB_USER}
 

--- a/saturnbase-julia/Dockerfile
+++ b/saturnbase-julia/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get -qq --allow-releaseinfo-change update && \
     echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     locale-gen
 
-ENV PATH /opt/conda/bin:$PATH
+ENV PATH /opt/saturncloud/bin:$PATH
 
 CMD [ "/bin/bash" ]
 
@@ -58,16 +58,16 @@ RUN set -x && \
     echo "${SHA256SUM} miniconda.sh" > shasum && \
     if [ "${CONDA_VERSION}" != "latest" ]; then sha256sum --check --status shasum; fi && \
     mkdir -p /opt && \
-    sh miniconda.sh -b -p /opt/conda && \
+    sh miniconda.sh -b -p /opt/saturncloud && \
     rm miniconda.sh shasum && \
-    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    ln -s /opt/saturncloud/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /opt/saturncloud/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \
-    find /opt/conda/ -follow -type f -name '*.a' -delete && \
-    find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
-    /opt/conda/bin/conda clean -afy && \
-    ln -s /opt/conda /srv/conda && \
-    chown -R 1000:1000 /opt/conda && \
+    find /opt/saturncloud/ -follow -type f -name '*.a' -delete && \
+    find /opt/saturncloud/ -follow -type f -name '*.js.map' -delete && \
+    /opt/saturncloud/bin/conda clean -afy && \
+    ln -s /opt/saturncloud /srv/conda && \
+    chown -R 1000:1000 /opt/saturncloud && \
     chown -R 1000:1000 /srv
 
 ENV LC_ALL=en_US.UTF-8

--- a/saturnbase-rstudio-bioconductor/Dockerfile
+++ b/saturnbase-rstudio-bioconductor/Dockerfile
@@ -37,7 +37,7 @@ RUN \
     && chown 1000:1000 -R /usr/lib/R \
     && chmod 777 -R /usr/lib/R \
     && su -c "echo 'R_LIBS=/usr/local/lib/R:/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library' >> /usr/local/lib/R/etc/Renviron" \
-    && su -c "echo 'RETICULATE_PYTHON=/opt/conda/envs/saturn/bin/python' >> /usr/local/lib/R/etc/Renviron" \
+    && su -c "echo 'RETICULATE_PYTHON=/opt/saturncloud/envs/saturn/bin/python' >> /usr/local/lib/R/etc/Renviron" \
     && su -c "echo 'RSTUDIO_PANDOC=/usr/lib/rstudio-server/bin/pandoc' >> /usr/local/lib/R/etc/Renviron" \
     && apt-get -qq --allow-releaseinfo-change update \
     # Install packages
@@ -121,10 +121,10 @@ RUN \
     # Give user sudo access
     && echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook \
     && mkdir -p ${APP_BASE} \
-    && mkdir -p /opt/conda \
-    && ln -s /opt/conda /srv/conda \
+    && mkdir -p /opt/saturncloud \
+    && ln -s /opt/saturncloud /srv/conda \
     # Give user ownership of conda and app
-    && chown 1000:1000 -R /opt/conda \
+    && chown 1000:1000 -R /opt/saturncloud \
     && chown -R $NB_USER:$NB_USER ${APP_BASE}
 
 USER ${NB_USER}

--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -37,7 +37,7 @@ RUN \
     && chown 1000:1000 -R /usr/lib/R \
     && chmod 777 -R /usr/lib/R \
     && su -c "echo 'R_LIBS=/usr/local/lib/R:/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library' >> /usr/local/lib/R/etc/Renviron" \
-    && su -c "echo 'RETICULATE_PYTHON=/opt/conda/envs/saturn/bin/python' >> /usr/local/lib/R/etc/Renviron" \
+    && su -c "echo 'RETICULATE_PYTHON=/opt/saturncloud/envs/saturn/bin/python' >> /usr/local/lib/R/etc/Renviron" \
     && su -c "echo 'RSTUDIO_PANDOC=/usr/lib/rstudio-server/bin/pandoc' >> /usr/local/lib/R/etc/Renviron" \
     && apt-get -qq --allow-releaseinfo-change update \
     # Install packages
@@ -130,10 +130,10 @@ RUN \
     # Give user sudo access
     && echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook \
     && mkdir -p ${APP_BASE} \
-    && mkdir -p /opt/conda \
-    && ln -s /opt/conda /srv/conda \
+    && mkdir -p /opt/saturncloud \
+    && ln -s /opt/saturncloud /srv/conda \
     # Give user ownership of conda and app
-    && chown 1000:1000 -R /opt/conda \
+    && chown 1000:1000 -R /opt/saturncloud \
     && chown -R $NB_USER:$NB_USER ${APP_BASE}
 
 USER ${NB_USER}

--- a/saturnbase-rstudio-workbench-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-workbench-gpu-11.1/Dockerfile
@@ -37,7 +37,7 @@ RUN \
     && chown 1000:1000 -R /usr/lib/R \
     && chmod 777 -R /usr/lib/R \
     && su -c "echo 'R_LIBS=/usr/local/lib/R:/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library' >> /usr/local/lib/R/etc/Renviron" \
-    && su -c "echo 'RETICULATE_PYTHON=/opt/conda/envs/saturn/bin/python' >> /usr/local/lib/R/etc/Renviron" \
+    && su -c "echo 'RETICULATE_PYTHON=/opt/saturncloud/envs/saturn/bin/python' >> /usr/local/lib/R/etc/Renviron" \
     && su -c "echo 'RSTUDIO_PANDOC=/usr/lib/rstudio-server/bin/pandoc' >> /usr/local/lib/R/etc/Renviron" \
     && apt-get -qq --allow-releaseinfo-change update \
     # Install packages
@@ -130,10 +130,10 @@ RUN \
     # Give user sudo access
     && echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook \
     && mkdir -p ${APP_BASE} \
-    && mkdir -p /opt/conda \
-    && ln -s /opt/conda /srv/conda \
+    && mkdir -p /opt/saturncloud \
+    && ln -s /opt/saturncloud /srv/conda \
     # Give user ownership of conda and app
-    && chown 1000:1000 -R /opt/conda \
+    && chown 1000:1000 -R /opt/saturncloud \
     && chown -R $NB_USER:$NB_USER ${APP_BASE} \
     # Give user ownership of rstudio files
     && sudo chown -R jovyan:jovyan /var/lib/rstudio-server/audit \

--- a/saturnbase-rstudio-workbench/Dockerfile
+++ b/saturnbase-rstudio-workbench/Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get -qq --allow-releaseinfo-change update && \
     echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     locale-gen
 
-ENV PATH /opt/conda/bin:$PATH
+ENV PATH /opt/saturncloud/bin:$PATH
 
 # Based on https://github.com/ContinuumIO/docker-images/blob/4d7798c0ea2463d9c4057d8eaee876102eecbf86/miniconda3/debian/Dockerfile
 ARG CONDA_VERSION=py39_4.10.3
@@ -75,16 +75,16 @@ RUN set -x && \
     echo "${SHA256SUM} miniconda.sh" > shasum && \
     if [ "${CONDA_VERSION}" != "latest" ]; then sha256sum --check --status shasum; fi && \
     mkdir -p /opt && \
-    sh miniconda.sh -b -p /opt/conda && \
+    sh miniconda.sh -b -p /opt/saturncloud && \
     rm miniconda.sh shasum && \
-    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    ln -s /opt/saturncloud/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /opt/saturncloud/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \
-    find /opt/conda/ -follow -type f -name '*.a' -delete && \
-    find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
-    /opt/conda/bin/conda clean -afy && \
-    ln -s /opt/conda /srv/conda && \
-    chown -R 1000:1000 /opt/conda && \
+    find /opt/saturncloud/ -follow -type f -name '*.a' -delete && \
+    find /opt/saturncloud/ -follow -type f -name '*.js.map' -delete && \
+    /opt/saturncloud/bin/conda clean -afy && \
+    ln -s /opt/saturncloud /srv/conda && \
+    chown -R 1000:1000 /opt/saturncloud && \
     chown -R 1000:1000 /srv
 
 ENV LC_ALL=en_US.UTF-8
@@ -138,7 +138,7 @@ RUN sudo mkdir -p /usr/local/lib/R \
     && sudo chown 1000:1000 -R /usr/lib/R \
     && sudo chmod 777 -R /usr/lib/R \
     && sudo su -c "echo 'R_LIBS=/usr/local/lib/R:/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library' >> /usr/lib/R/etc/Renviron" \
-    && sudo su -c "echo 'RETICULATE_PYTHON=/opt/conda/envs/saturn/bin/python' >> /usr/lib/R/etc/Renviron" \
+    && sudo su -c "echo 'RETICULATE_PYTHON=/opt/saturncloud/envs/saturn/bin/python' >> /usr/lib/R/etc/Renviron" \
     && sudo su -c "echo 'RSTUDIO_PANDOC=/usr/lib/rstudio-server/bin/pandoc' >> /usr/lib/R/etc/Renviron"
 
 ## Install RStudio

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get -qq --allow-releaseinfo-change update && \
     echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     locale-gen
 
-ENV PATH /opt/conda/bin:$PATH
+ENV PATH /opt/saturncloud/bin:$PATH
 
 # Based on https://github.com/ContinuumIO/docker-images/blob/4d7798c0ea2463d9c4057d8eaee876102eecbf86/miniconda3/debian/Dockerfile
 ARG CONDA_VERSION=py39_4.10.3
@@ -75,16 +75,16 @@ RUN set -x && \
     echo "${SHA256SUM} miniconda.sh" > shasum && \
     if [ "${CONDA_VERSION}" != "latest" ]; then sha256sum --check --status shasum; fi && \
     mkdir -p /opt && \
-    sh miniconda.sh -b -p /opt/conda && \
+    sh miniconda.sh -b -p /opt/saturncloud && \
     rm miniconda.sh shasum && \
-    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    ln -s /opt/saturncloud/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /opt/saturncloud/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \
-    find /opt/conda/ -follow -type f -name '*.a' -delete && \
-    find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
-    /opt/conda/bin/conda clean -afy && \
-    ln -s /opt/conda /srv/conda && \
-    chown -R 1000:1000 /opt/conda && \
+    find /opt/saturncloud/ -follow -type f -name '*.a' -delete && \
+    find /opt/saturncloud/ -follow -type f -name '*.js.map' -delete && \
+    /opt/saturncloud/bin/conda clean -afy && \
+    ln -s /opt/saturncloud /srv/conda && \
+    chown -R 1000:1000 /opt/saturncloud && \
     chown -R 1000:1000 /srv
 
 ENV LC_ALL=en_US.UTF-8
@@ -138,7 +138,7 @@ RUN sudo mkdir -p /usr/local/lib/R \
     && sudo chown 1000:1000 -R /usr/lib/R \
     && sudo chmod 777 -R /usr/lib/R \
     && sudo su -c "echo 'R_LIBS=/usr/local/lib/R:/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library' >> /usr/lib/R/etc/Renviron" \
-    && sudo su -c "echo 'RETICULATE_PYTHON=/opt/conda/envs/saturn/bin/python' >> /usr/lib/R/etc/Renviron" \
+    && sudo su -c "echo 'RETICULATE_PYTHON=/opt/saturncloud/envs/saturn/bin/python' >> /usr/lib/R/etc/Renviron" \
     && sudo su -c "echo 'RSTUDIO_PANDOC=/usr/lib/rstudio-server/bin/pandoc' >> /usr/lib/R/etc/Renviron" \
     && sudo su -c "echo 'options(repos = c(CRAN = \"https://packagemanager.rstudio.com/cran/__linux__/focal/latest\"), download.file.method = \"libcurl\")' >> /usr/lib/R/etc/Rprofile.site" \
     && sudo su -c "echo 'options(HTTPUserAgent = sprintf(\"R/%s R (%s)\", getRversion(), paste(getRversion(), R.version\$platform, R.version\$arch, R.version\$os)))' >> /usr/lib/R/etc/Rprofile.site"

--- a/saturnbase/Dockerfile
+++ b/saturnbase/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get -qq --allow-releaseinfo-change update && \
     echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     locale-gen
 
-ENV PATH /opt/conda/bin:$PATH
+ENV PATH /opt/saturncloud/bin:$PATH
 
 CMD [ "/bin/bash" ]
 
@@ -48,16 +48,16 @@ RUN set -x && \
     echo "${SHA256SUM} miniconda.sh" > shasum && \
     if [ "${CONDA_VERSION}" != "latest" ]; then sha256sum --check --status shasum; fi && \
     mkdir -p /opt && \
-    sh miniconda.sh -b -p /opt/conda && \
+    sh miniconda.sh -b -p /opt/saturncloud && \
     rm miniconda.sh shasum && \
-    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    ln -s /opt/saturncloud/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /opt/saturncloud/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \
-    find /opt/conda/ -follow -type f -name '*.a' -delete && \
-    find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
-    /opt/conda/bin/conda clean -afy && \
-    ln -s /opt/conda /srv/conda && \
-    chown -R 1000:1000 /opt/conda && \
+    find /opt/saturncloud/ -follow -type f -name '*.a' -delete && \
+    find /opt/saturncloud/ -follow -type f -name '*.js.map' -delete && \
+    /opt/saturncloud/bin/conda clean -afy && \
+    ln -s /opt/saturncloud /srv/conda && \
+    chown -R 1000:1000 /opt/saturncloud && \
     chown -R 1000:1000 /srv
 
 ENV LC_ALL=en_US.UTF-8

--- a/saturnbase/install-jupyter.bash
+++ b/saturnbase/install-jupyter.bash
@@ -17,7 +17,7 @@ npm cache clean --force
 find ${CONDA_DIR}/ -type f,l -name '*.pyc' -delete
 find ${CONDA_DIR}/ -type f,l -name '*.a' -delete
 find ${CONDA_DIR}/ -type f,l -name '*.js.map' -delete
-find /opt/conda/lib/python*/site-packages/bokeh/server/static/ -follow -type f -name '*.js' ! -name '*.min.js' -delete
+find /opt/saturncloud/lib/python*/site-packages/bokeh/server/static/ -follow -type f -name '*.js' ! -name '*.min.js' -delete
 rm -rf $HOME/.node-gyp
 rm -rf $HOME/.local
 


### PR DESCRIPTION
The reason to move /opt/conda to /opt/saturncloud is to increase
compatibility with images we import - if we pull in an image that is
using /opt/conda for something else, we can populate /opt/saturncloud
and work with the image without issue.

Ref: DEV-3152
