### PR TITLE
Add linux library required for targets

### DIFF
--- a/saturnbase-rstudio-bioconductor/Dockerfile
+++ b/saturnbase-rstudio-bioconductor/Dockerfile
@@ -76,6 +76,7 @@ RUN \
         wget \
         unixodbc \
         unixodbc-dev \
+        libglpk-dev \
      > /dev/null
 
 RUN \

--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -77,6 +77,7 @@ RUN \
         wget \
         unixodbc \
         unixodbc-dev \
+        libglpk-dev \
      > /dev/null \
     # CUDA fix
     && ln -s /usr/local/cuda-11.1/targets/x86_64-linux/lib/libcusolver.so.11 /usr/local/lib/libcusolver.so.10 \

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get -qq --allow-releaseinfo-change update && \
         rrdtool \
         unixodbc \
         unixodbc-dev \
+        libglpk-dev \
      > /dev/null && \
     # add snowflake ODBC driver
     sudo apt-get install -f && \


### PR DESCRIPTION
This adds a linux library required for targets. I added it to all R base images, however I suspect that it's already installed in the GPU and bioconductor ones