### PR TITLE
Fix Pandoc in RStudio

### DIFF
--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get -qq --allow-releaseinfo-change update && \
         rrdtool \
         unixodbc \
         unixodbc-dev \
+        pandoc \
      > /dev/null && \
     # add snowflake ODBC driver
     sudo apt-get install -f && \
@@ -135,7 +136,6 @@ RUN sudo mkdir -p /usr/lib/R/site-library \
     && sudo chmod 777 -R /usr/lib/R \
     && sudo su -c "echo 'R_LIBS=/usr/lib/R/site-library:/usr/lib/R/library' >> /usr/lib/R/etc/Renviron.site" \
     && sudo su -c "echo 'RETICULATE_PYTHON=/opt/conda/envs/saturn/bin/python' >> /usr/lib/R/etc/Renviron.site" \
-    && sudo su -c "echo 'RSTUDIO_PANDOC=/usr/lib/rstudio-server/bin/pandoc' >> /usr/lib/R/etc/Renviron.site" \
     && sudo su -c "echo 'options(repos = c(CRAN = \"https://packagemanager.rstudio.com/cran/__linux__/focal/latest\"), download.file.method = \"libcurl\")' >> /usr/lib/R/etc/Rprofile.site" \
     && sudo su -c "echo 'options(HTTPUserAgent = sprintf(\"R/%s R (%s)\", getRversion(), paste(getRversion(), R.version\$platform, R.version\$arch, R.version\$os)))' >> /usr/lib/R/etc/Rprofile.site"
 


### PR DESCRIPTION
When we switched to Ubuntu somehow pandoc stopped being installed with RStudio. instead I am installing it manually. In this situation we no longer need to add an environment variable to specify which pandoc to use