### PR TITLE
Remove 'saturncloud/' from image names

### DIFF
--- a/saturn-geospatial/recipe-template.json
+++ b/saturn-geospatial/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturn-geospatial",
+    "name": "saturn-geospatial",
     "description": "A Python image containing libraries specific to geospatial IO, analysis, and visualization. Generally used for CPU instances.",
     "hardware_type": "cpu",
     "supports": ["jupyterlab", "dask"]

--- a/saturn-julia-gpu/recipe-template.json
+++ b/saturn-julia-gpu/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturn-julia-gpu",
+    "name": "saturn-julia-gpu",
     "description": "A GPU Julia image for Saturn Cloud. Contains Julia and Python along with a selection of popular Julia GPU packages.",
     "hardware_type": "gpu",
     "supports": [

--- a/saturn-julia/recipe-template.json
+++ b/saturn-julia/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturn-julia",
+    "name": "saturn-julia",
     "description": "A Julia image for Saturn Cloud. Contains Julia and Python along with a selection of popular Julia packages.",
     "hardware_type": "cpu",
     "supports": [

--- a/saturn-pytorch/recipe-template.json
+++ b/saturn-pytorch/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturn-pytorch",
+    "name": "saturn-pytorch",
     "description": "For deep learning with PyTorch. Includes all requirements for using PyTorch on a GPU and with Dask.",
     "hardware_type": "gpu",
     "supports": ["jupyterlab", "dask"]

--- a/saturn-rapids/recipe-template.json
+++ b/saturn-rapids/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturn-rapids",
+    "name": "saturn-rapids",
     "description": "For GPU-based acceleration using the RAPIDS library.",
     "hardware_type": "gpu",
     "supports": ["jupyterlab", "dask"]

--- a/saturn-rstudio-bioconductor/recipe-template.json
+++ b/saturn-rstudio-bioconductor/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturn-rstudio-bioconductor",
+    "name": "saturn-rstudio-bioconductor",
     "description": "An R and RStudio image built with full Bioconductor support",
     "hardware_type": "cpu",
     "supports": ["rstudio-opensource"]

--- a/saturn-rstudio-parallel/recipe-template.json
+++ b/saturn-rstudio-parallel/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturn-rstudio-parallel",
+    "name": "saturn-rstudio-parallel",
     "description": "For running parallel computations in RStudio",
     "hardware_type": "cpu",
     "supports": [

--- a/saturn-rstudio-tensorflow/recipe-template.json
+++ b/saturn-rstudio-tensorflow/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturn-rstudio-tensorflow",
+    "name": "saturn-rstudio-tensorflow",
     "description": "For running TensorFlow on a GPU in RStudio.",
     "hardware_type": "gpu",
     "supports": ["rstudio-opensource"]

--- a/saturn-rstudio-torch/recipe-template.json
+++ b/saturn-rstudio-torch/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturn-rstudio-torch",
+    "name": "saturn-rstudio-torch",
     "description": "For running Torch on a GPU in RStudio.",
     "hardware_type": "gpu",
     "supports": ["rstudio-opensource"]

--- a/saturn-rstudio-workbench-parallel/recipe-template.json
+++ b/saturn-rstudio-workbench-parallel/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturn-rstudio-workbench-parallel",
+    "name": "saturn-rstudio-workbench-parallel",
     "description": "For running parallel computations in RStudio Workbench",
     "hardware_type": "cpu",
     "supports": [

--- a/saturn-rstudio-workbench-tensorflow/recipe-template.json
+++ b/saturn-rstudio-workbench-tensorflow/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturn-rstudio-tensorflow",
+    "name": "saturn-rstudio-tensorflow",
     "description": "For running TensorFlow on a GPU in RStudio.",
     "hardware_type": "gpu",
     "supports": ["rstudio-opensource"]

--- a/saturn-rstudio-workbench-torch/recipe-template.json
+++ b/saturn-rstudio-workbench-torch/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturn-rstudio-workbench-torch",
+    "name": "saturn-rstudio-workbench-torch",
     "description": "For running Torch on a GPU in RStudio Workbench.",
     "hardware_type": "gpu",
     "supports": ["rstudio-workbench"]

--- a/saturn-rstudio-workbench/recipe-template.json
+++ b/saturn-rstudio-workbench/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturn-rstudio-workbench",
+    "name": "saturn-rstudio-workbench",
     "description": "For basic analysis using R and RStudio Workbench.",
     "hardware_type": "cpu",
     "supports": ["rstudio-workbench"]

--- a/saturn-rstudio/recipe-template.json
+++ b/saturn-rstudio/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturn-rstudio",
+    "name": "saturn-rstudio",
     "description": "For basic analysis using R and RStudio.",
     "hardware_type": "cpu",
     "supports": ["rstudio-opensource"]

--- a/saturn-tensorflow/recipe-template.json
+++ b/saturn-tensorflow/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturn-tensorflow",
+    "name": "saturn-tensorflow",
     "description": "For deep learning with TensorFlow. Includes all requirements for using TensorFlow on a GPU.",
     "hardware_type": "gpu",
     "supports": ["jupyterlab", "dask"]

--- a/saturn/recipe-template.json
+++ b/saturn/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturn",
+    "name": "saturn",
     "description": "For basic Python data analysis, machine learning, and parallel processing with Dask.",
     "hardware_type": "cpu",
     "supports": ["jupyterlab", "dask"]

--- a/saturnbase-gpu-10.1/recipe-template.json
+++ b/saturnbase-gpu-10.1/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturnbase-gpu-10.1",
+    "name": "saturnbase-gpu-10.1",
     "description": "Python-focused base image for Saturn GPU images, built on CUDA version 10.1. This image contains the minimal install required for the full functionality of Saturn Cloud on a GPU instance, including packages necessary to run Python, JupyterLab, and Dask.",
     "hardware_type": "gpu",
     "supports": ["jupyterlab", "dask"]

--- a/saturnbase-gpu-11.1/recipe-template.json
+++ b/saturnbase-gpu-11.1/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturnbase-gpu-11.1",
+    "name": "saturnbase-gpu-11.1",
     "description": "Python-focused base image for Saturn GPU images, built on CUDA version 11.1. This image contains the minimal install required for the full functionality of Saturn Cloud on a GPU instance, including packages necessary to run Python, JupyterLab, and Dask.",
     "hardware_type": "gpu",
     "supports": ["jupyterlab", "dask"]

--- a/saturnbase-gpu-11.2/recipe-template.json
+++ b/saturnbase-gpu-11.2/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturnbase-gpu-11.2",
+    "name": "saturnbase-gpu-11.2",
     "description": "Python-focused base image for Saturn GPU images, built on CUDA version 11.2. This image contains the minimal install required for the full functionality of Saturn Cloud on a GPU instance, including packages necessary to run Python, JupyterLab, and Dask.",
     "hardware_type": "gpu",
     "supports": ["jupyterlab", "dask"]

--- a/saturnbase-julia-gpu-11.3/recipe-template.json
+++ b/saturnbase-julia-gpu-11.3/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturnbase-julia-gpu-11.3",
+    "name": "saturnbase-julia-gpu-11.3",
     "description": "The base GPU image for Julia. This image contains all of the requirements to run Julia 1.7.2 and Python on Saturn Cloud using Nvidia CUDA 11.3",
     "hardware_type": "gpu",
     "supports": [

--- a/saturnbase-julia/recipe-template.json
+++ b/saturnbase-julia/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturnbase-julia",
+    "name": "saturnbase-julia",
     "description": "The base image for Julia. This image contains all of the requirements to run Julia 1.7.2 and Python on Saturn Cloud.",
     "hardware_type": "cpu",
     "supports": [

--- a/saturnbase-rstudio-bioconductor/recipe-template.json
+++ b/saturnbase-rstudio-bioconductor/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturnbase-rstudio-bioconductor",
+    "name": "saturnbase-rstudio-bioconductor",
     "description": "R-focused base image for Saturn RStudio images, based on Bioconductor's RStudio image.",
     "hardware_type": "cpu",
     "supports": ["rstudio-opensource"]

--- a/saturnbase-rstudio-gpu-11.1/recipe-template.json
+++ b/saturnbase-rstudio-gpu-11.1/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturnbase-rstudio-gpu-11.1",
+    "name": "saturnbase-rstudio-gpu-11.1",
     "description": "R-focused base image for Saturn RStudio GPU images, built on CUDA version 11.1 using rocker/ml (https://github.com/rocker-org/rocker-versioned2). This image contains the packages necessary to run R, RStudio, Python, and Reticulate.",
     "hardware_type": "gpu",
     "supports": ["rstudio-opensource"]

--- a/saturnbase-rstudio-workbench-gpu-11.1/recipe-template.json
+++ b/saturnbase-rstudio-workbench-gpu-11.1/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturnbase-rstudio-workbench-gpu-11.1",
+    "name": "saturnbase-rstudio-workbench-gpu-11.1",
     "description": "R-focused base image for Saturn RStudio GPU images, built on CUDA version 11.1 using rocker/ml (https://github.com/rocker-org/rocker-versioned2). This image contains the packages necessary to run R, RStudio, Python, and Reticulate.",
     "hardware_type": "gpu",
     "supports": ["rstudio-workbench"]

--- a/saturnbase-rstudio-workbench/recipe-template.json
+++ b/saturnbase-rstudio-workbench/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturnbase-rstudio-workbench",
+    "name": "saturnbase-rstudio-workbench",
     "description": "R-focused base image for Saturn RStudio images. This image contains the packages necessary to run R, RStudio, and Python and sets up environment variables for Reticulate support. Also installs a few libraries that are useful for Markdown support.",
     "hardware_type": "cpu",
     "supports": ["rstudio-workbench"]

--- a/saturnbase-rstudio/recipe-template.json
+++ b/saturnbase-rstudio/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturnbase-rstudio",
+    "name": "saturnbase-rstudio",
     "description": "R-focused base image for Saturn RStudio images. This image contains the packages necessary to run R, RStudio, and Python and sets up environment variables for Reticulate support. Also installs a few libraries that are useful for Markdown support.",
     "hardware_type": "cpu",
     "supports": ["rstudio-opensource"]

--- a/saturnbase/recipe-template.json
+++ b/saturnbase/recipe-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "saturncloud/saturnbase",
+    "name": "saturnbase",
     "description": "Python-focused base image for Saturn CPU images. This image contains the minimal install required for the full functionality of Saturn Cloud, including the packages necessary to run Python, JupyterLab, and Dask.",
     "hardware_type": "cpu",
     "supports": ["jupyterlab", "dask"]


### PR DESCRIPTION
This corresponds with upcoming application changes to handle these standard images differently.