### PR TITLE
Update GPG key for cuda repos

### DIFF
--- a/saturnbase-gpu-10.1/Dockerfile
+++ b/saturnbase-gpu-10.1/Dockerfile
@@ -7,7 +7,9 @@ ENV APP_BASE=/srv
 ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -qq --allow-releaseinfo-change update && \
+RUN apt-key del 7fa2af80 && \
+    rm /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list && \
+    apt-get -qq --allow-releaseinfo-change update && \
     apt-get -qq upgrade -y && \
     apt-get -qq install --yes --no-install-recommends \
         gettext-base \
@@ -29,6 +31,9 @@ RUN apt-get -qq --allow-releaseinfo-change update && \
         build-essential \
         libnuma-dev \
      > /dev/null && \
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb && \
+    dpkg -i cuda-keyring_1.0-1_all.deb && \
+    rm cuda-keyring_1.0-1_all.deb && \
     apt-get -qq purge && \
     apt-get -qq clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/saturnbase-gpu-11.1/Dockerfile
+++ b/saturnbase-gpu-11.1/Dockerfile
@@ -11,7 +11,9 @@ ENV APP_BASE=/srv
 ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -qq --allow-releaseinfo-change update && \
+RUN apt-key del 7fa2af80 && \
+    rm /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list && \
+    apt-get -qq --allow-releaseinfo-change update && \
     apt-get -qq upgrade -y && \
     apt-get -qq install --yes --no-install-recommends \
         gettext-base \
@@ -33,6 +35,9 @@ RUN apt-get -qq --allow-releaseinfo-change update && \
         build-essential \
         libnuma-dev \
      > /dev/null && \
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb && \
+    dpkg -i cuda-keyring_1.0-1_all.deb && \
+    rm cuda-keyring_1.0-1_all.deb && \
     apt-get -qq purge && \
     apt-get -qq clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/saturnbase-gpu-11.2/Dockerfile
+++ b/saturnbase-gpu-11.2/Dockerfile
@@ -7,7 +7,9 @@ ENV APP_BASE=/srv
 ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -qq update && \
+RUN apt-key del 7fa2af80 && \
+    rm /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list && \
+    apt-get -qq --allow-releaseinfo-change update && \
     apt-get -qq upgrade -y && \
     apt-get -qq install --yes --no-install-recommends \
         gettext-base \
@@ -29,6 +31,9 @@ RUN apt-get -qq update && \
         build-essential \
         libnuma-dev \
      > /dev/null && \
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb && \
+    dpkg -i cuda-keyring_1.0-1_all.deb && \
+    rm cuda-keyring_1.0-1_all.deb && \
     apt-get -qq purge && \
     apt-get -qq clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/saturnbase-julia-gpu-11.3/Dockerfile
+++ b/saturnbase-julia-gpu-11.3/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-key del 7fa2af80 && \
     zip \ 
     unzip \
     > /dev/null && \
-    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb && \
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb && \
     dpkg -i cuda-keyring_1.0-1_all.deb && \
     rm cuda-keyring_1.0-1_all.deb && \
     apt-get -qq purge && \

--- a/saturnbase-julia-gpu-11.3/Dockerfile
+++ b/saturnbase-julia-gpu-11.3/Dockerfile
@@ -15,7 +15,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV JULIA_DEPOT_PATH=/srv/julia
 ENV JULIA_PKGDIR=/srv/julia
 
-RUN apt-get -qq --allow-releaseinfo-change update && \
+RUN apt-key del 7fa2af80 && \
+    rm /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list && \
+    apt-get -qq --allow-releaseinfo-change update && \
     apt-get -qq upgrade -y && \
     apt-get -qq install --yes --no-install-recommends \
     awscli \
@@ -41,6 +43,9 @@ RUN apt-get -qq --allow-releaseinfo-change update && \
     zip \ 
     unzip \
     > /dev/null && \
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb && \
+    dpkg -i cuda-keyring_1.0-1_all.deb && \
+    rm cuda-keyring_1.0-1_all.deb && \
     apt-get -qq purge && \
     apt-get -qq clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -85,7 +85,7 @@ RUN apt-key del 7fa2af80 \
         unixodbc \
         unixodbc-dev \
      > /dev/null \
-    && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb \
+    && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb \
     && dpkg -i cuda-keyring_1.0-1_all.deb \
     && rm cuda-keyring_1.0-1_all.deb \
     # CUDA fix

--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -26,7 +26,9 @@ ARG RSTUDIO_VERSION=2021.09.0-351
 
 ARG TINI_VERSION=0.18.0
 
-RUN \
+RUN apt-key del 7fa2af80 \
+    && rm /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list \
+    && apt-get -qq --allow-releaseinfo-change update \
     # Make all library folders readable then let R known, then set up reticulate package
     mkdir -p /usr/local/lib/R \
     && mkdir -p /usr/local/lib/R/site-library \
@@ -83,6 +85,9 @@ RUN \
         unixodbc \
         unixodbc-dev \
      > /dev/null \
+    && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb \
+    && dpkg -i cuda-keyring_1.0-1_all.deb \
+    && rm cuda-keyring_1.0-1_all.deb \
     # CUDA fix
     && ln -s /usr/local/cuda-11.1/targets/x86_64-linux/lib/libcusolver.so.11 /usr/local/lib/libcusolver.so.10 \
     # Install rstudio-server

--- a/saturnbase-rstudio-workbench-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-workbench-gpu-11.1/Dockerfile
@@ -26,7 +26,9 @@ ARG RSTUDIO_WORKBENCH_VERSION=2021.09.2-382.pro1
 
 ARG TINI_VERSION=0.18.0
 
-RUN \
+RUN apt-key del 7fa2af80 \
+    && rm /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list \
+    && apt-get -qq --allow-releaseinfo-change update \
     # Make all library folders readable then let R known, then set up reticulate package
     mkdir -p /usr/local/lib/R \
     && mkdir -p /usr/local/lib/R/site-library \
@@ -83,6 +85,9 @@ RUN \
         unixodbc \
         unixodbc-dev \
      > /dev/null \
+    && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb \
+    && dpkg -i cuda-keyring_1.0-1_all.deb \
+    && rm cuda-keyring_1.0-1_all.deb \
     # CUDA fix
     && ln -s /usr/local/cuda-11.1/targets/x86_64-linux/lib/libcusolver.so.11 /usr/local/lib/libcusolver.so.10 \
     # Install rstudio-server

--- a/saturnbase-rstudio-workbench-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-workbench-gpu-11.1/Dockerfile
@@ -85,7 +85,7 @@ RUN apt-key del 7fa2af80 \
         unixodbc \
         unixodbc-dev \
      > /dev/null \
-    && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb \
+    && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb \
     && dpkg -i cuda-keyring_1.0-1_all.deb \
     && rm cuda-keyring_1.0-1_all.deb \
     # CUDA fix


### PR DESCRIPTION
This PR updates removes nvidia's now-invalid GPG key and repos from the apt lists in the GPU base images, and installs a tool to manage it better going forward.

For context: https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772