### PR TITLE
add `-f` to nvidia apt source `rm`

### DIFF
--- a/saturnbase-gpu-10.1/Dockerfile
+++ b/saturnbase-gpu-10.1/Dockerfile
@@ -8,7 +8,7 @@ ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-key del 7fa2af80 && \
-    rm /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list && \
+    rm -f /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list && \
     apt-get -qq --allow-releaseinfo-change update && \
     apt-get -qq upgrade -y && \
     apt-get -qq install --yes --no-install-recommends \

--- a/saturnbase-gpu-11.1/Dockerfile
+++ b/saturnbase-gpu-11.1/Dockerfile
@@ -12,7 +12,7 @@ ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-key del 7fa2af80 && \
-    rm /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list && \
+    rm -f /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list && \
     apt-get -qq --allow-releaseinfo-change update && \
     apt-get -qq upgrade -y && \
     apt-get -qq install --yes --no-install-recommends \

--- a/saturnbase-gpu-11.2/Dockerfile
+++ b/saturnbase-gpu-11.2/Dockerfile
@@ -8,7 +8,7 @@ ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-key del 7fa2af80 && \
-    rm /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list && \
+    rm -f /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list && \
     apt-get -qq --allow-releaseinfo-change update && \
     apt-get -qq upgrade -y && \
     apt-get -qq install --yes --no-install-recommends \

--- a/saturnbase-julia-gpu-11.3/Dockerfile
+++ b/saturnbase-julia-gpu-11.3/Dockerfile
@@ -16,7 +16,7 @@ ENV JULIA_DEPOT_PATH=/srv/julia
 ENV JULIA_PKGDIR=/srv/julia
 
 RUN apt-key del 7fa2af80 && \
-    rm /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list && \
+    rm -f /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list && \
     apt-get -qq --allow-releaseinfo-change update && \
     apt-get -qq upgrade -y && \
     apt-get -qq install --yes --no-install-recommends \

--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -27,7 +27,7 @@ ARG RSTUDIO_VERSION=2022.02.1-461
 ARG TINI_VERSION=0.18.0
 
 RUN apt-key del 7fa2af80 \
-    && rm /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list \
+    && rm -f /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list \
     && apt-get -qq --allow-releaseinfo-change update \
     # Make all library folders readable then let R known, then set up reticulate package
     && mkdir -p "/usr/local/lib/R/site-library" \

--- a/saturnbase-rstudio-workbench-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-workbench-gpu-11.1/Dockerfile
@@ -27,7 +27,7 @@ ARG RSTUDIO_WORKBENCH_VERSION=2021.09.2-382.pro1
 ARG TINI_VERSION=0.18.0
 
 RUN apt-key del 7fa2af80 \
-    && rm /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list \
+    && rm -f /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list \
     && apt-get -qq --allow-releaseinfo-change update \
     # Make all library folders readable then let R known, then set up reticulate package
     && mkdir -p /usr/local/lib/R \


### PR DESCRIPTION
Last week, these files needed to be removed because nvidia had not yet updated their cuda images for the GPG key rotations. Now, they have, and these files no longer exist. We should still keep these clean steps in, for future-proofing - but adding `-f` will cause the removal not to error out if they do not exist.