### PR TITLE
Fix R/RStudio versions

### DIFF
--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/cuda:cuda11.1
+FROM rocker/cuda:4.2.0-cuda11.1
 EXPOSE 8888
 
 LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -124,7 +124,9 @@ RUN sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key 'E298A3A825C0D6
     "echo 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/' >>/etc/apt/sources.list" && \
     sudo apt update && \
     sudo apt-get install -y -t focal-cran40 \
-        r-base \
+        r-base=4.2.0-1~bullseyecran.0 && \
+    sudo apt-mark hold r-base && \
+    sudo apt-get install -y -t focal-cran40 \
         r-base-core \
         r-base-dev 
 


### PR DESCRIPTION
This fixes R and RStudio so that they don't change if we update the image in the future.

* The `saturnbase-rstudio` image now fixes the R version when it pulls from apt-get
* The `saturnbase-gpu` image now builds off a rocker container that has a fixed version