### PR TITLE
Fix R/RStudio versions for 2022.03.01 release

### DIFF
--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/cuda:cuda11.1
+FROM rocker/cuda:4.2.0-cuda11.1
 EXPOSE 8888
 
 LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
@@ -22,7 +22,7 @@ ENV NB_UID=1000
 ENV USER=${NB_USER}
 ENV HOME=/home/${NB_USER}
 
-ARG RSTUDIO_VERSION=2021.09.0-351
+ARG RSTUDIO_VERSION=2022.02.1-461
 
 ARG TINI_VERSION=0.18.0
 

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -124,7 +124,9 @@ RUN sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key '95C0FAF38DB3CC
     "echo 'deb http://cloud.r-project.org/bin/linux/debian bullseye-cran40/' >>/etc/apt/sources.list" && \
     sudo apt update && \
     sudo apt-get install -y -t bullseye-cran40 \
-        r-base \
+        r-base=4.2.0-1~bullseyecran.0 && \
+    sudo apt-mark hold r-base && \
+    sudo apt-get install -y -t bullseye-cran40 \
         r-base-core \
         r-base-dev 
 
@@ -143,7 +145,7 @@ RUN sudo mkdir -p /usr/local/lib/R \
 
 ## Install RStudio
 
-ARG RSTUDIO_VERSION=2021.09.0-351
+ARG RSTUDIO_VERSION=2022.02.1-461
 
 ARG TINI_VERSION=0.18.0
 


### PR DESCRIPTION
Similar to #382 and #386, this fixes the R and RStudio versions for our 3.01 images.