### PR TITLE
Release 01.06 - Changed R to 4.1.3

### DIFF
--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/cuda:4.2.0-cuda11.1
+FROM rocker/cuda:4.1.3-cuda11.1
 ENV CONDA_OVERRIDE_CUDA=11.1
 EXPOSE 8888
 

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -124,7 +124,7 @@ RUN sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key '95C0FAF38DB3CC
     "echo 'deb http://cloud.r-project.org/bin/linux/debian bullseye-cran40/' >>/etc/apt/sources.list" && \
     sudo apt update && \
     sudo apt-get install -y -t bullseye-cran40 \
-        r-base=4.2.0-1~bullseyecran.0 && \
+        r-base=4.1.3-1~bullseyecran.0 && \
     sudo apt-mark hold r-base && \
     sudo apt-get install -y -t bullseye-cran40 \
         r-base-core \


### PR DESCRIPTION
This changes the R version in `saturnbase-rstudio` and `saturnbase-rstudio-gpu-11.1` to R 4.1.3, which is previously what it was
