### PR TITLE
Converge on Rocker images and fix versions for main

### DIFF
--- a/saturn-rstudio-bioconductor/postBuild
+++ b/saturn-rstudio-bioconductor/postBuild
@@ -16,5 +16,5 @@ Rscript -e "install.packages(c( \
         'tidyverse' \
     ), Ncpus = max(c(1, parallel::detectCores() - 1)), \
     dependencies = c('LinkingTo', 'Depends', 'Imports'), \
-    repos = 'https://packagemanager.rstudio.com/cran/__linux__/focal/latest' \
+    repos = '${CRAN_FIXED}' \
     )"

--- a/saturn-rstudio-tensorflow/postBuild
+++ b/saturn-rstudio-tensorflow/postBuild
@@ -18,5 +18,5 @@ Rscript -e "install.packages(c( \
         'keras' \
     ), Ncpus = max(c(1, parallel::detectCores() - 1)), \
     dependencies = c('LinkingTo', 'Depends', 'Imports'), \
-    repos = 'https://packagemanager.rstudio.com/cran/__linux__/focal/latest' \
+    repos = '{$CRAN_FIXED}' \
     )"

--- a/saturn-rstudio-torch/postBuild
+++ b/saturn-rstudio-torch/postBuild
@@ -20,7 +20,7 @@ Rscript -e "install.packages(c( \
         'torchvision' \
     ), Ncpus = max(c(1, parallel::detectCores() - 1)), \
     dependencies = c('LinkingTo', 'Depends', 'Imports'), \
-    repos = 'https://packagemanager.rstudio.com/cran/__linux__/focal/latest' \
+    repos = '{$CRAN_FIXED}' \
     )"
 
 Rscript -e "torch::install_torch()"

--- a/saturn-rstudio/postBuild
+++ b/saturn-rstudio/postBuild
@@ -16,5 +16,5 @@ Rscript -e "install.packages(c( \
         'tidyverse' \
     ), Ncpus = max(c(1, parallel::detectCores() - 1)), \
     dependencies = c('LinkingTo', 'Depends', 'Imports'), \
-    repos = 'https://packagemanager.rstudio.com/cran/__linux__/focal/latest' \
+    repos = '${CRAN_FIXED}' \
     )"

--- a/saturnbase-rstudio-bioconductor/Dockerfile
+++ b/saturnbase-rstudio-bioconductor/Dockerfile
@@ -25,6 +25,8 @@ ENV NB_USER=jovyan
 ENV NB_UID=1000
 ENV USER=${NB_USER}
 ENV HOME=/home/${NB_USER}
+ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/latest
+ENV CRAN_FIXED=https://packagemanager.rstudio.com/cran/__linux__/focal/2022-04-01
 
 ARG TINI_VERSION=0.18.0
 
@@ -89,16 +91,6 @@ RUN \
     # Runtime settings ------------------------------------------------------------#
     && sudo curl -L -o /usr/local/bin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini \
     && sudo chmod +x /usr/local/bin/tini \
-    # Add a few R packages that are useful for RMarkdown
-    && Rscript -e "install.packages(c( \
-        'jquerylib', \
-        'markdown', \
-        'rmarkdown', \
-        'tinytex' \
-        ), Ncpus = max(c(1, parallel::detectCores() - 1)), \
-        dependencies = c('LinkingTo', 'Depends', 'Imports'), \
-        lib = '/usr/local/lib/R/site-library' \
-        )" \
     # add snowflake ODBC driver
     && sudo apt-get install -f \
     && wget https://sfc-repo.snowflakecomputing.com/odbc/linux/2.24.0/snowflake-odbc-2.24.0.x86_64.deb -O snowflake-odbc.deb \
@@ -122,9 +114,25 @@ RUN \
     && ln -s /opt/saturncloud /srv/conda \
     # Give user ownership of conda and app
     && chown 1000:1000 -R /opt/saturncloud \
-    && chown -R $NB_USER:$NB_USER ${APP_BASE}
+    && chown -R $NB_USER:$NB_USER ${APP_BASE} \
+    # Set the default repo to the latest rstudio package manager
+    && grep -v "options(repos = c(CRAN" "${R_HOME}/etc/Rprofile.site" > tmp.txt && mv tmp.txt "${R_HOME}/etc/Rprofile.site" \
+    && echo "options(repos = c(CRAN = '${CRAN}'), download.file.method = 'libcurl')" >>"${R_HOME}/etc/Rprofile.site"
+    
 
 USER ${NB_USER}
+
+# Add a few R packages that are useful for RMarkdown
+RUN Rscript -e "install.packages(c( \
+        'jquerylib', \
+        'markdown', \
+        'rmarkdown', \
+        'tinytex' \
+        ), Ncpus = max(c(1, parallel::detectCores() - 1)), \
+        dependencies = c('LinkingTo', 'Depends', 'Imports'), \
+        lib = '/usr/local/lib/R/site-library', \
+        repos = '${CRAN_FIXED}'\
+        )" 
 
 COPY install-miniconda.bash /tmp/install-miniconda.bash
 COPY setup-conda.bash /tmp/setup-conda.bash

--- a/saturnbase-rstudio-bioconductor/Dockerfile
+++ b/saturnbase-rstudio-bioconductor/Dockerfile
@@ -70,6 +70,7 @@ RUN \
         openssh-client \
         openssh-server \
         openssl \
+        pandoc \
         psmisc \
         qpdf \
         rrdtool \

--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -118,7 +118,7 @@ RUN apt-key del 7fa2af80 \
     --gecos "Default user" \
     --uid ${NB_UID} \
     ${NB_USER} && \
-    echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook && \
+    echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook \
     # Give user sudo access
     && echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook \
     && mkdir -p ${APP_BASE} \

--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -71,6 +71,7 @@ RUN apt-key del 7fa2af80 \
         openssh-client \
         openssh-server \
         openssl \
+        pandoc \
         psmisc \
         qpdf \
         rrdtool \

--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -131,9 +131,12 @@ RUN apt-key del 7fa2af80 \
     && chown -R $NB_USER:$NB_USER ${APP_BASE} \
     # Set the default repo to the latest rstudio package manager
     && grep -v "options(repos = c(CRAN" "${R_HOME}/etc/Rprofile.site" > tmp.txt && mv tmp.txt "${R_HOME}/etc/Rprofile.site" \
-    && echo "options(repos = c(CRAN = '${CRAN}'), download.file.method = 'libcurl')" >>"${R_HOME}/etc/Rprofile.site" \
-    # Add a few R packages that are useful for RMarkdown
-    && Rscript -e "install.packages(c( \
+    && echo "options(repos = c(CRAN = '${CRAN}'), download.file.method = 'libcurl')" >>"${R_HOME}/etc/Rprofile.site" 
+
+USER ${NB_USER}
+
+# Add a few R packages that are useful for RMarkdown
+RUN Rscript -e "install.packages(c( \
         'jquerylib', \
         'markdown', \
         'rmarkdown', \
@@ -143,9 +146,6 @@ RUN apt-key del 7fa2af80 \
         lib = '/usr/local/lib/R/site-library', \
         repos = '${CRAN_FIXED}'\
         )" 
-
-USER ${NB_USER}
-
 COPY install-miniconda.bash /tmp/install-miniconda.bash
 COPY setup-conda.bash /tmp/setup-conda.bash
 COPY environment.yml /tmp/environment.yml

--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -146,6 +146,7 @@ RUN Rscript -e "install.packages(c( \
         lib = '/usr/local/lib/R/site-library', \
         repos = '${CRAN_FIXED}'\
         )" 
+
 COPY install-miniconda.bash /tmp/install-miniconda.bash
 COPY setup-conda.bash /tmp/setup-conda.bash
 COPY environment.yml /tmp/environment.yml

--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -27,8 +27,6 @@ ARG RSTUDIO_VERSION=2022.02.1-461
 
 ARG TINI_VERSION=0.18.0
 
-RUN useradd -ms /bin/bash joyvan
-
 RUN apt-key del 7fa2af80 \
     && rm -f /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list \
     && apt-get -qq --allow-releaseinfo-change update \

--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -1,4 +1,7 @@
 FROM rocker/cuda:4.2.0-cuda11.1
+RUN usermod -l jovyan rstudio
+RUN groupmod -n jovyan rstudio
+RUN usermod -d /home/jovyan jovyan
 ENV CONDA_OVERRIDE_CUDA=11.1
 EXPOSE 8888
 
@@ -97,18 +100,6 @@ RUN apt-key del 7fa2af80 \
     # Runtime settings ------------------------------------------------------------#
     && sudo curl -L -o /usr/local/bin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini \
     && sudo chmod +x /usr/local/bin/tini \
-    # Add the jovan user
-    && useradd -ms /bin/bash joyvan \
-    # Add a few R packages that are useful for RMarkdown
-    && Rscript -e "install.packages(c( \
-        'jquerylib', \
-        'markdown', \
-        'rmarkdown', \
-        'tinytex' \
-        ), Ncpus = max(c(1, parallel::detectCores() - 1)), \
-        dependencies = c('LinkingTo', 'Depends', 'Imports'), \
-        lib = '/usr/local/lib/R/site-library' \
-        )" \
     # add snowflake ODBC driver
     && sudo apt-get install -f \
     && wget https://sfc-repo.snowflakecomputing.com/odbc/linux/2.24.0/snowflake-odbc-2.24.0.x86_64.deb -O snowflake-odbc.deb \
@@ -125,11 +116,6 @@ RUN apt-key del 7fa2af80 \
     # Generate locales
     && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
     && locale-gen \
-    # Create user
-    && adduser --disabled-password \
-        --gecos "Default user" \
-        --uid ${NB_UID} \
-        ${NB_USER} \
     # Give user sudo access
     && echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook \
     && mkdir -p ${APP_BASE} \
@@ -137,7 +123,17 @@ RUN apt-key del 7fa2af80 \
     && ln -s /opt/saturncloud /srv/conda \
     # Give user ownership of conda and app
     && chown 1000:1000 -R /opt/saturncloud \
-    && chown -R $NB_USER:$NB_USER ${APP_BASE}
+    && chown -R $NB_USER:$NB_USER ${APP_BASE} \
+    # Add a few R packages that are useful for RMarkdown
+    && Rscript -e "install.packages(c( \
+        'jquerylib', \
+        'markdown', \
+        'rmarkdown', \
+        'tinytex' \
+        ), Ncpus = max(c(1, parallel::detectCores() - 1)), \
+        dependencies = c('LinkingTo', 'Depends', 'Imports'), \
+        lib = '/usr/local/lib/R/site-library' \
+        )"
 
 USER ${NB_USER}
 

--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -114,7 +114,7 @@ RUN apt-key del 7fa2af80 \
     && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
     && locale-gen \
     # add user
-    adduser --disabled-password \
+    && adduser --disabled-password \
     --gecos "Default user" \
     --uid ${NB_UID} \
     ${NB_USER} && \

--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -1,7 +1,4 @@
 FROM rocker/cuda:4.2.0-cuda11.1
-RUN usermod -l jovyan rstudio
-RUN groupmod -n jovyan rstudio
-RUN usermod -d /home/jovyan jovyan
 ENV CONDA_OVERRIDE_CUDA=11.1
 EXPOSE 8888
 
@@ -116,6 +113,12 @@ RUN apt-key del 7fa2af80 \
     # Generate locales
     && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
     && locale-gen \
+    # add user
+    adduser --disabled-password \
+    --gecos "Default user" \
+    --uid ${NB_UID} \
+    ${NB_USER} && \
+    echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook && \
     # Give user sudo access
     && echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook \
     && mkdir -p ${APP_BASE} \

--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -22,6 +22,8 @@ ENV NB_USER=jovyan
 ENV NB_UID=1000
 ENV USER=${NB_USER}
 ENV HOME=/home/${NB_USER}
+ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/latest
+ENV CRAN_FIXED=https://packagemanager.rstudio.com/cran/__linux__/focal/2022-04-01
 
 ARG RSTUDIO_VERSION=2022.02.1-461
 
@@ -127,6 +129,9 @@ RUN apt-key del 7fa2af80 \
     # Give user ownership of conda and app
     && chown 1000:1000 -R /opt/saturncloud \
     && chown -R $NB_USER:$NB_USER ${APP_BASE} \
+    # Set the default repo to the latest rstudio package manager
+    && grep -v "options(repos = c(CRAN" "${R_HOME}/etc/Rprofile.site" > tmp.txt && mv tmp.txt "${R_HOME}/etc/Rprofile.site" \
+    && echo "options(repos = c(CRAN = '${CRAN}'), download.file.method = 'libcurl')" >>"${R_HOME}/etc/Rprofile.site" \
     # Add a few R packages that are useful for RMarkdown
     && Rscript -e "install.packages(c( \
         'jquerylib', \
@@ -135,8 +140,9 @@ RUN apt-key del 7fa2af80 \
         'tinytex' \
         ), Ncpus = max(c(1, parallel::detectCores() - 1)), \
         dependencies = c('LinkingTo', 'Depends', 'Imports'), \
-        lib = '/usr/local/lib/R/site-library' \
-        )"
+        lib = '/usr/local/lib/R/site-library', \
+        repos = '${CRAN_FIXED}'\
+        )" 
 
 USER ${NB_USER}
 

--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -27,6 +27,12 @@ ARG RSTUDIO_VERSION=2022.02.1-461
 
 ARG TINI_VERSION=0.18.0
 
+RUN apt-get update --fix-missing \
+    && apt-get upgrade -y \
+    && apt-get install --yes --no-install-recommends gnupg
+
+RUN useradd -ms /bin/bash joyvan
+
 RUN apt-key del 7fa2af80 \
     && rm -f /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list \
     && apt-get -qq --allow-releaseinfo-change update \
@@ -97,6 +103,8 @@ RUN apt-key del 7fa2af80 \
     # Runtime settings ------------------------------------------------------------#
     && sudo curl -L -o /usr/local/bin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini \
     && sudo chmod +x /usr/local/bin/tini \
+    # Add the jovan user
+    && useradd -ms /bin/bash joyvan \
     # Add a few R packages that are useful for RMarkdown
     && Rscript -e "install.packages(c( \
         'jquerylib', \

--- a/saturnbase-rstudio-gpu-11.1/Dockerfile
+++ b/saturnbase-rstudio-gpu-11.1/Dockerfile
@@ -27,10 +27,6 @@ ARG RSTUDIO_VERSION=2022.02.1-461
 
 ARG TINI_VERSION=0.18.0
 
-RUN apt-get update --fix-missing \
-    && apt-get upgrade -y \
-    && apt-get install --yes --no-install-recommends gnupg
-
 RUN useradd -ms /bin/bash joyvan
 
 RUN apt-key del 7fa2af80 \

--- a/saturnbase-rstudio/.dockerignore
+++ b/saturnbase-rstudio/.dockerignore
@@ -7,3 +7,4 @@
 !rsession-profile
 !rstudio-prefs.json
 !rstudio-start.sh
+!install-miniconda.bash

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -20,12 +20,14 @@ ENV NB_USER=jovyan
 ENV NB_UID=1000
 ENV USER=${NB_USER}
 ENV HOME=/home/${NB_USER}
+ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/latest
+ENV CRAN_FIXED=https://packagemanager.rstudio.com/cran/__linux__/focal/2022-04-01
 
 ARG RSTUDIO_VERSION=2022.02.1-461
 
 ARG TINI_VERSION=0.18.0
 
-RUN  apt-get -qq --allow-releaseinfo-change update \
+RUN apt-get -qq --allow-releaseinfo-change update \
     # Make all library folders readable then let R known, then set up reticulate package
     && mkdir -p "/usr/local/lib/R/site-library" \
     && chown 1000:1000 -R /usr/local/lib/R \
@@ -118,7 +120,10 @@ RUN  apt-get -qq --allow-releaseinfo-change update \
     # Give user ownership of conda and app
     && chown 1000:1000 -R /opt/saturncloud \
     && chown -R $NB_USER:$NB_USER ${APP_BASE} \
-        # Add a few R packages that are useful for RMarkdown
+    # Set the default repo to the latest rstudio package manager
+    && grep -v "options(repos = c(CRAN" "${R_HOME}/etc/Rprofile.site" > tmp.txt && mv tmp.txt "${R_HOME}/etc/Rprofile.site" \
+    && echo "options(repos = c(CRAN = '${CRAN}'), download.file.method = 'libcurl')" >>"${R_HOME}/etc/Rprofile.site" \
+    # Add a few R packages that are useful for RMarkdown
     && Rscript -e "install.packages(c( \
         'jquerylib', \
         'markdown', \
@@ -127,6 +132,7 @@ RUN  apt-get -qq --allow-releaseinfo-change update \
         ), Ncpus = max(c(1, parallel::detectCores() - 1)), \
         dependencies = c('LinkingTo', 'Depends', 'Imports'), \
         lib = '/usr/local/lib/R/site-library' \
+        repos = '${CRAN_FIXED}'\
         )" 
 
 USER ${NB_USER}

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -131,7 +131,7 @@ RUN apt-get -qq --allow-releaseinfo-change update \
         'tinytex' \
         ), Ncpus = max(c(1, parallel::detectCores() - 1)), \
         dependencies = c('LinkingTo', 'Depends', 'Imports'), \
-        lib = '/usr/local/lib/R/site-library' \
+        lib = '/usr/local/lib/R/site-library', \
         repos = '${CRAN_FIXED}'\
         )" 
 

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -123,8 +123,11 @@ RUN apt-get -qq --allow-releaseinfo-change update \
     # Set the default repo to the latest rstudio package manager
     && grep -v "options(repos = c(CRAN" "${R_HOME}/etc/Rprofile.site" > tmp.txt && mv tmp.txt "${R_HOME}/etc/Rprofile.site" \
     && echo "options(repos = c(CRAN = '${CRAN}'), download.file.method = 'libcurl')" >>"${R_HOME}/etc/Rprofile.site" \
-    # Add a few R packages that are useful for RMarkdown
-    && Rscript -e "install.packages(c( \
+
+USER ${NB_USER}
+
+# Add a few R packages that are useful for RMarkdown
+RUN Rscript -e "install.packages(c( \
         'jquerylib', \
         'markdown', \
         'rmarkdown', \
@@ -134,8 +137,6 @@ RUN apt-get -qq --allow-releaseinfo-change update \
         lib = '/usr/local/lib/R/site-library', \
         repos = '${CRAN_FIXED}'\
         )" 
-
-USER ${NB_USER}
 
 COPY install-miniconda.bash /tmp/install-miniconda.bash
 COPY setup-conda.bash /tmp/setup-conda.bash

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -1,7 +1,4 @@
 FROM rocker/r-ver:4.2.0
-RUN usermod -l jovyan rstudio
-RUN groupmod -n jovyan rstudio
-RUN usermod -d /home/jovyan jovyan
 
 LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.source="https://github.com/saturncloud/images" \

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -122,7 +122,7 @@ RUN apt-get -qq --allow-releaseinfo-change update \
     && chown -R $NB_USER:$NB_USER ${APP_BASE} \
     # Set the default repo to the latest rstudio package manager
     && grep -v "options(repos = c(CRAN" "${R_HOME}/etc/Rprofile.site" > tmp.txt && mv tmp.txt "${R_HOME}/etc/Rprofile.site" \
-    && echo "options(repos = c(CRAN = '${CRAN}'), download.file.method = 'libcurl')" >>"${R_HOME}/etc/Rprofile.site" \
+    && echo "options(repos = c(CRAN = '${CRAN}'), download.file.method = 'libcurl')" >>"${R_HOME}/etc/Rprofile.site"
 
 USER ${NB_USER}
 

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -1,5 +1,4 @@
 FROM rocker/r-ver:4.2.0
-ENV CONDA_OVERRIDE_CUDA=11.1
 EXPOSE 8888
 
 LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
@@ -40,6 +39,7 @@ RUN apt-key del 7fa2af80 \
     # Install packages
     && apt-get update --fix-missing \
     && apt-get upgrade -y \
+    && apt-get install --yes --no-install-recommends gnupg\
     && apt-get install --yes --no-install-recommends \
         awscli \
         build-essential \
@@ -51,7 +51,6 @@ RUN apt-key del 7fa2af80 \
         gdebi-core \
         gettext-base \
         git \
-        gnupg \
         htop \
         libcap2 \
         libcurl4-openssl-dev \
@@ -95,6 +94,8 @@ RUN apt-key del 7fa2af80 \
     # Runtime settings ------------------------------------------------------------#
     && sudo curl -L -o /usr/local/bin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini \
     && sudo chmod +x /usr/local/bin/tini \
+    # Add the jovan user
+    && useradd -ms /bin/bash joyvan \
     # Add a few R packages that are useful for RMarkdown
     && Rscript -e "install.packages(c( \
         'jquerylib', \

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -1,5 +1,7 @@
 FROM rocker/r-ver:4.2.0
-EXPOSE 8888
+RUN usermod -l jovyan rstudio
+RUN groupmod -n jovyan rstudio
+RUN usermod -d /home/jovyan jovyan
 
 LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.source="https://github.com/saturncloud/images" \
@@ -26,13 +28,7 @@ ARG RSTUDIO_VERSION=2022.02.1-461
 
 ARG TINI_VERSION=0.18.0
 
-RUN apt-get update --fix-missing \
-    && apt-get upgrade -y \
-    && apt-get install --yes --no-install-recommends gnupg
-
-RUN apt-key del 7fa2af80 \
-    && rm -f /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list \
-    && apt-get -qq --allow-releaseinfo-change update \
+RUN  apt-get -qq --allow-releaseinfo-change update \
     # Make all library folders readable then let R known, then set up reticulate package
     && mkdir -p "/usr/local/lib/R/site-library" \
     && chown 1000:1000 -R /usr/local/lib/R \
@@ -43,7 +39,6 @@ RUN apt-key del 7fa2af80 \
     # Install packages
     && apt-get update --fix-missing \
     && apt-get upgrade -y \
-    && apt-get install --yes --no-install-recommends gnupg\
     && apt-get install --yes --no-install-recommends \
         awscli \
         build-essential \
@@ -55,6 +50,7 @@ RUN apt-key del 7fa2af80 \
         gdebi-core \
         gettext-base \
         git \
+        gnupg \
         htop \
         libcap2 \
         libcurl4-openssl-dev \
@@ -84,9 +80,6 @@ RUN apt-key del 7fa2af80 \
         unixodbc-dev \
         libglpk-dev \
      > /dev/null \
-    && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb \
-    && dpkg -i cuda-keyring_1.0-1_all.deb \
-    && rm cuda-keyring_1.0-1_all.deb \
     # Install rstudio-server
     && curl -o rstudio.deb https://download2.rstudio.org/server/bionic/amd64/rstudio-server-${RSTUDIO_VERSION}-amd64.deb \
     && sudo gdebi --non-interactive rstudio.deb \
@@ -98,18 +91,6 @@ RUN apt-key del 7fa2af80 \
     # Runtime settings ------------------------------------------------------------#
     && sudo curl -L -o /usr/local/bin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini \
     && sudo chmod +x /usr/local/bin/tini \
-    # Add the jovan user
-    && useradd -ms /bin/bash joyvan \
-    # Add a few R packages that are useful for RMarkdown
-    && Rscript -e "install.packages(c( \
-        'jquerylib', \
-        'markdown', \
-        'rmarkdown', \
-        'tinytex' \
-        ), Ncpus = max(c(1, parallel::detectCores() - 1)), \
-        dependencies = c('LinkingTo', 'Depends', 'Imports'), \
-        lib = '/usr/local/lib/R/site-library' \
-        )" \
     # add snowflake ODBC driver
     && sudo apt-get install -f \
     && wget https://sfc-repo.snowflakecomputing.com/odbc/linux/2.24.0/snowflake-odbc-2.24.0.x86_64.deb -O snowflake-odbc.deb \
@@ -126,11 +107,6 @@ RUN apt-key del 7fa2af80 \
     # Generate locales
     && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
     && locale-gen \
-    # Create user
-    && adduser --disabled-password \
-        --gecos "Default user" \
-        --uid ${NB_UID} \
-        ${NB_USER} \
     # Give user sudo access
     && echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook \
     && mkdir -p ${APP_BASE} \
@@ -138,7 +114,17 @@ RUN apt-key del 7fa2af80 \
     && ln -s /opt/saturncloud /srv/conda \
     # Give user ownership of conda and app
     && chown 1000:1000 -R /opt/saturncloud \
-    && chown -R $NB_USER:$NB_USER ${APP_BASE}
+    && chown -R $NB_USER:$NB_USER ${APP_BASE} \
+        # Add a few R packages that are useful for RMarkdown
+    && Rscript -e "install.packages(c( \
+        'jquerylib', \
+        'markdown', \
+        'rmarkdown', \
+        'tinytex' \
+        ), Ncpus = max(c(1, parallel::detectCores() - 1)), \
+        dependencies = c('LinkingTo', 'Depends', 'Imports'), \
+        lib = '/usr/local/lib/R/site-library' \
+        )" 
 
 USER ${NB_USER}
 

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -104,6 +104,12 @@ RUN  apt-get -qq --allow-releaseinfo-change update \
     # Generate locales
     && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
     && locale-gen \
+    # add user
+    adduser --disabled-password \
+    --gecos "Default user" \
+    --uid ${NB_UID} \
+    ${NB_USER} && \
+    echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook && \
     # Give user sudo access
     && echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook \
     && mkdir -p ${APP_BASE} \

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -1,155 +1,91 @@
-FROM ubuntu:focal
+FROM rocker/r-ver:4.2.0
+ENV CONDA_OVERRIDE_CUDA=11.1
 EXPOSE 8888
 
-# SETUP SATURN
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/saturncloud/images" \
+      org.opencontainers.image.vendor="Saturn Cloud" \
+      org.opencontainers.image.authors="Jacqueline Nolis" \
+      org.opencontainers.image.description="Additions to rocker/r-ver to support running on Saturn Cloud"
+
+# SETUP SATURN (and install linux libraries for R & Rstudio)
 
 ENV APP_BASE=/srv
 ENV CONDA_DIR=/srv/conda
 ENV CONDA_BIN=${CONDA_DIR}/bin
 ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get -qq --allow-releaseinfo-change update && \
-    apt-get -qq upgrade -y && \
-    apt-get -qq install --yes --no-install-recommends \
-        awscli \
-        build-essential \
-        bzip2 \
-        ca-certificates \
-        curl \
-        htop \
-        gettext-base \
-        git \
-        gnupg \
-        locales \
-        openssh-client \
-        openssh-server \
-        procps \
-        rsync \
-        sudo \
-        screen \
-        wget \
-        devscripts \
-        libxml2 \
-        libxml2-dev \
-        libcurl4-openssl-dev \
-        libssl-dev \
-        libzmq3-dev \
-        qpdf \
-        gdebi-core \
-        libcap2 \
-        libglib2.0-0 \
-        libpq5 \
-        libsm6 \
-        libcurl4-openssl-dev \
-        libssl1.1 \
-        openssl \
-        libuser \
-        libuser1-dev \
-        openssh-client \
-        rrdtool \
-        unixodbc \
-        unixodbc-dev \
-        pandoc \
-        libglpk-dev \
-     > /dev/null && \
-    # add snowflake ODBC driver
-    sudo apt-get install -f && \
-    wget https://sfc-repo.snowflakecomputing.com/odbc/linux/2.24.0/snowflake-odbc-2.24.0.x86_64.deb -O snowflake-odbc.deb && \
-    sudo dpkg -i snowflake-odbc.deb && \
-    sudo wget https://saturn-public-data.s3.us-east-2.amazonaws.com/r-odbc/odbc.ini -O /usr/lib/snowflake/odbc/lib/odbc.ini && \
-    sudo wget https://saturn-public-data.s3.us-east-2.amazonaws.com/r-odbc/odbcinst.ini -O /usr/lib/snowflake/odbc/lib/odbcinst.ini && \
-    apt-get -qq purge && \
-    apt-get -qq clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    mkdir -p /run/sshd && \
-    chmod 755 /run/sshd && \
-    echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
-    locale-gen
-
-ENV PATH /opt/saturncloud/bin:$PATH
-
-# Based on https://github.com/ContinuumIO/docker-images/blob/4d7798c0ea2463d9c4057d8eaee876102eecbf86/miniconda3/debian/Dockerfile
-ARG CONDA_VERSION=py39_4.10.3
-RUN set -x && \
-    MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh"; \
-    SHA256SUM="1ea2f885b4dbc3098662845560bc64271eb17085387a70c2ba3f29fff6f8d52f"; \
-    wget "${MINICONDA_URL}" -O miniconda.sh -q && \
-    echo "${SHA256SUM} miniconda.sh" > shasum && \
-    if [ "${CONDA_VERSION}" != "latest" ]; then sha256sum --check --status shasum; fi && \
-    mkdir -p /opt && \
-    sh miniconda.sh -b -p /opt/saturncloud && \
-    rm miniconda.sh shasum && \
-    ln -s /opt/saturncloud/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-    echo ". /opt/saturncloud/etc/profile.d/conda.sh" >> ~/.bashrc && \
-    echo "conda activate base" >> ~/.bashrc && \
-    find /opt/saturncloud/ -follow -type f -name '*.a' -delete && \
-    find /opt/saturncloud/ -follow -type f -name '*.js.map' -delete && \
-    /opt/saturncloud/bin/conda clean -afy && \
-    ln -s /opt/saturncloud /srv/conda && \
-    chown -R 1000:1000 /opt/saturncloud && \
-    chown -R 1000:1000 /srv
-
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
-ENV LANGUAGE=en_US.UTF-8
-ENV SHELL=/bin/bash
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV SHELL /bin/bash
 ENV NB_USER=jovyan
 ENV NB_UID=1000
 ENV USER=${NB_USER}
 ENV HOME=/home/${NB_USER}
 
-RUN adduser --disabled-password \
-    --gecos "Default user" \
-    --uid ${NB_UID} \
-    ${NB_USER} && \
-    echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook
-COPY profile /etc/profile
-
-USER ${NB_USER}
-
-COPY setup-conda.bash /tmp/setup-conda.bash
-COPY environment.yml /tmp/environment.yml
-RUN bash /tmp/setup-conda.bash && \
-    echo '' > ${CONDA_DIR}/conda-meta/history && \
-    ${CONDA_BIN}/conda config --system --add channels conda-forge && \
-    ${CONDA_BIN}/conda config --system --set auto_update_conda false && \
-    ${CONDA_BIN}/conda config --system --set show_channel_urls true
-ENV NPM_DIR ${APP_BASE}/npm
-ENV NB_PYTHON_PREFIX ${CONDA_DIR}/envs/saturn
-ENV PATH ${NB_PYTHON_PREFIX}/bin:${CONDA_BIN}:${NPM_DIR}/bin:${HOME}/.local/bin:${PATH}
-WORKDIR ${HOME}
-
-## Install R
-
-RUN sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key 'E298A3A825C0D65DFD57CBB651716619E084DAB9' && \
-    sudo su -c \
-    "echo 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/' >>/etc/apt/sources.list" && \
-    sudo apt update && \
-    sudo apt-get install -y -t focal-cran40 \
-        r-base=4.2.0-1.2004.0 && \
-    sudo apt-mark hold r-base && \
-    sudo apt-get install -y -t focal-cran40 \
-        r-base-core \
-        r-base-dev 
-
-# Make all library folders readable then let R known, the set up reticulate and pandoc packages
-RUN sudo mkdir -p /usr/lib/R/site-library \
-    && sudo mkdir -p /usr/lib/R/library \
-    && sudo chown 1000:1000 -R /usr/lib/R \
-    && sudo chmod 777 -R /usr/lib/R \
-    && sudo su -c "echo 'R_LIBS=/usr/lib/R/site-library:/usr/lib/R/library' >> /usr/lib/R/etc/Renviron.site" \
-    && sudo su -c "echo 'RETICULATE_PYTHON=/opt/saturncloud/envs/saturn/bin/python' >> /usr/lib/R/etc/Renviron.site" \
-    && sudo su -c "echo 'options(repos = c(CRAN = \"https://packagemanager.rstudio.com/cran/__linux__/focal/latest\"), download.file.method = \"libcurl\")' >> /usr/lib/R/etc/Rprofile.site" \
-    && sudo su -c "echo 'options(HTTPUserAgent = sprintf(\"R/%s R (%s)\", getRversion(), paste(getRversion(), R.version\$platform, R.version\$arch, R.version\$os)))' >> /usr/lib/R/etc/Rprofile.site"
-
-## Install RStudio
-
 ARG RSTUDIO_VERSION=2022.02.1-461
 
 ARG TINI_VERSION=0.18.0
 
-# hadolint ignore=DL3008,DL3009
-RUN curl -o rstudio.deb https://download2.rstudio.org/server/bionic/amd64/rstudio-server-${RSTUDIO_VERSION}-amd64.deb \
+RUN apt-key del 7fa2af80 \
+    && rm -f /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list \
+    && apt-get -qq --allow-releaseinfo-change update \
+    # Make all library folders readable then let R known, then set up reticulate package
+    && mkdir -p "/usr/local/lib/R/site-library" \
+    && chown 1000:1000 -R /usr/local/lib/R \
+    && chmod 777 -R /usr/local/lib/R \
+    && su -c "echo 'RETICULATE_PYTHON=/opt/saturncloud/envs/saturn/bin/python' >> /usr/local/lib/R/etc/Renviron.site" \
+    && su -c "echo 'RSTUDIO_PANDOC=/usr/lib/rstudio-server/bin/pandoc' >> /usr/local/lib/R/etc/Renviron.site" \
+    && apt-get -qq --allow-releaseinfo-change update \
+    # Install packages
+    && apt-get update --fix-missing \
+    && apt-get upgrade -y \
+    && apt-get install --yes --no-install-recommends \
+        awscli \
+        build-essential \
+        bzip2 \
+        ca-certificates \
+        curl \
+        devscripts \
+        file \
+        gdebi-core \
+        gettext-base \
+        git \
+        gnupg \
+        htop \
+        libcap2 \
+        libcurl4-openssl-dev \
+        libglib2.0-0 \
+        libpq5 \
+        libsm6 \
+        libssl-dev \
+        libssl1.1 \
+        libuser \
+        libuser1-dev \
+        libxml2 \
+        libxml2-dev \
+        libzmq3-dev \
+        locales \
+        openssh-client \
+        openssh-server \
+        openssl \
+        psmisc \
+        qpdf \
+        rrdtool \
+        rsync \
+        screen \
+        ssh \
+        sudo \
+        wget \
+        unixodbc \
+        unixodbc-dev \
+        libglpk-dev \
+     > /dev/null \
+    && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb \
+    && dpkg -i cuda-keyring_1.0-1_all.deb \
+    && rm cuda-keyring_1.0-1_all.deb \
+    # Install rstudio-server
+    && curl -o rstudio.deb https://download2.rstudio.org/server/bionic/amd64/rstudio-server-${RSTUDIO_VERSION}-amd64.deb \
     && sudo gdebi --non-interactive rstudio.deb \
     && rm rstudio.deb \
     && sudo apt purge \
@@ -164,10 +100,60 @@ RUN curl -o rstudio.deb https://download2.rstudio.org/server/bionic/amd64/rstudi
         'jquerylib', \
         'markdown', \
         'rmarkdown', \
-        'tinytex'), \
-        lib = '/usr/lib/R/site-library')" \
-    && sudo rm -rf /tmp/*
+        'tinytex' \
+        ), Ncpus = max(c(1, parallel::detectCores() - 1)), \
+        dependencies = c('LinkingTo', 'Depends', 'Imports'), \
+        lib = '/usr/local/lib/R/site-library' \
+        )" \
+    # add snowflake ODBC driver
+    && sudo apt-get install -f \
+    && wget https://sfc-repo.snowflakecomputing.com/odbc/linux/2.24.0/snowflake-odbc-2.24.0.x86_64.deb -O snowflake-odbc.deb \
+    && sudo dpkg -i snowflake-odbc.deb \
+    && sudo wget https://saturn-public-data.s3.us-east-2.amazonaws.com/r-odbc/odbc.ini -O /usr/lib/snowflake/odbc/lib/odbc.ini \
+    && sudo wget https://saturn-public-data.s3.us-east-2.amazonaws.com/r-odbc/odbcinst.ini -O /usr/lib/snowflake/odbc/lib/odbcinst.ini \
+    # Cleanup
+    && sudo rm -rf /tmp/* \
+    && apt-get -qq purge \
+    && apt-get -qq clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /run/sshd \
+    && chmod 755 /run/sshd \
+    # Generate locales
+    && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
+    && locale-gen \
+    # Create user
+    && adduser --disabled-password \
+        --gecos "Default user" \
+        --uid ${NB_UID} \
+        ${NB_USER} \
+    # Give user sudo access
+    && echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook \
+    && mkdir -p ${APP_BASE} \
+    && mkdir -p /opt/saturncloud \
+    && ln -s /opt/saturncloud /srv/conda \
+    # Give user ownership of conda and app
+    && chown 1000:1000 -R /opt/saturncloud \
+    && chown -R $NB_USER:$NB_USER ${APP_BASE}
 
+USER ${NB_USER}
+
+COPY install-miniconda.bash /tmp/install-miniconda.bash
+COPY setup-conda.bash /tmp/setup-conda.bash
+COPY environment.yml /tmp/environment.yml
+
+# Install miniconda
+RUN bash /tmp/install-miniconda.bash && \
+    bash /tmp/setup-conda.bash && \
+    echo '' > ${CONDA_DIR}/conda-meta/history && \
+    ${CONDA_BIN}/conda config --system --add channels conda-forge && \
+    ${CONDA_BIN}/conda config --system --set auto_update_conda false && \
+    ${CONDA_BIN}/conda config --system --set show_channel_urls true
+ENV NPM_DIR ${APP_BASE}/npm
+ENV NB_PYTHON_PREFIX ${CONDA_DIR}/envs/saturn
+ENV PATH ${NB_PYTHON_PREFIX}/bin:${CONDA_BIN}:${NPM_DIR}/bin:${HOME}/.local/bin:${PATH}
+WORKDIR ${HOME}
+
+# Configure rstudio
 COPY --chown=root:root rstudio-start.sh /usr/local/bin/rstudio-start.sh
 RUN sudo chmod +x /usr/local/bin/rstudio-start.sh
 

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -105,7 +105,7 @@ RUN  apt-get -qq --allow-releaseinfo-change update \
     && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
     && locale-gen \
     # add user
-    adduser --disabled-password \
+    && adduser --disabled-password \
     --gecos "Default user" \
     --uid ${NB_UID} \
     ${NB_USER} && \

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -109,7 +109,7 @@ RUN  apt-get -qq --allow-releaseinfo-change update \
     --gecos "Default user" \
     --uid ${NB_UID} \
     ${NB_USER} && \
-    echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook && \
+    echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook \
     # Give user sudo access
     && echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook \
     && mkdir -p ${APP_BASE} \

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -30,8 +30,6 @@ RUN apt-get update --fix-missing \
     && apt-get upgrade -y \
     && apt-get install --yes --no-install-recommends gnupg
 
-RUN useradd -ms /bin/bash joyvan
-
 RUN apt-key del 7fa2af80 \
     && rm -f /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list \
     && apt-get -qq --allow-releaseinfo-change update \

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -26,6 +26,12 @@ ARG RSTUDIO_VERSION=2022.02.1-461
 
 ARG TINI_VERSION=0.18.0
 
+RUN apt-get update --fix-missing \
+    && apt-get upgrade -y \
+    && apt-get install --yes --no-install-recommends gnupg
+
+RUN useradd -ms /bin/bash joyvan
+
 RUN apt-key del 7fa2af80 \
     && rm -f /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list \
     && apt-get -qq --allow-releaseinfo-change update \

--- a/saturnbase-rstudio/Dockerfile
+++ b/saturnbase-rstudio/Dockerfile
@@ -67,6 +67,7 @@ RUN apt-get -qq --allow-releaseinfo-change update \
         openssh-client \
         openssh-server \
         openssl \
+        pandoc \
         psmisc \
         qpdf \
         rrdtool \

--- a/saturnbase-rstudio/install-miniconda.bash
+++ b/saturnbase-rstudio/install-miniconda.bash
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -ex
+
+cd $(dirname $0)
+
+MINICONDA_VERSION=py38_4.9.2
+URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
+INSTALLER_PATH=/tmp/miniconda-installer.sh
+wget --quiet $URL -O ${INSTALLER_PATH}
+chmod +x ${INSTALLER_PATH}
+
+MD5SUM="122c8c9beb51e124ab32a0fa6426c656"
+
+if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
+    echo "md5sum mismatch for ${INSTALLER_PATH}, exiting!"
+    exit 1
+fi
+
+bash ${INSTALLER_PATH} -b -p ${CONDA_DIR} -f
+
+export PATH="${CONDA_BIN}:$PATH"
+
+# Update conda
+conda update -y conda
+
+# Allow easy direct installs from conda forge
+conda config --system --add channels conda-forge
+conda config --system --set auto_update_conda false
+conda config --system --set show_channel_urls true


### PR DESCRIPTION
This PR makes it so that all of our images are directly or indirectly built from versioned rocker images:

* `saturnbase-rstudio` - builds from `rocker/r-ver:4.2.0`
* `saturnbase-rstudio-gpu-11.1` - builds from `rocker/cuda:4.2.0-cuda11.1`
* `saturnbase-rstudio-bioconductor` - builds from `bioconductor/bioconductor_docker:RELEASE_3_14` which is build from `rocker/rstudio:latest`

For any Rocker image, the latest version of it lets the R packages float, however older versions then fix the R packages to

The latest versions of R in rocker images (version 4.2.0) let the R packages float, however when R updates to a new version, the rocker maintainers then lock in the R packages to a particular date (see the [docs](https://github.com/rocker-org/rocker-versioned2/wiki/Versions)). For our purposes we always want the R packages to be fixed during build but float when running. Thus, the images now explicitly install packages from a fixed date when running install commands within the image, otherwise they update to using the latest R packages for the user.

For us to make our releases of the images the right version (like the `release-2022.01.06` image having R 4.1.3), we need to:

1. Use the correct base image of Rocker
2. Set the `CRAN_FIXED` url to have the correct date for installing packages.

I have tested the following:

* `saturn-rstudio` builds correctly and runs without errors
* `saturn-rstudio-tensorflow` builds correctly (I did not run it)
