### PR TITLE
Upgrade TensorFlow

### DIFF
--- a/saturn-python-tensorflow/Dockerfile
+++ b/saturn-python-tensorflow/Dockerfile
@@ -12,3 +12,5 @@ RUN mamba env update -n saturn --file /tmp/environment.yml && \
     find ${CONDA_DIR} -type f,l -name '*.a' -delete && \
     find ${CONDA_DIR} -type f,l -name '*.js.map' -delete
 RUN echo '' > ${CONDA_DIR}/envs/saturn/conda-meta/history
+
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:/opt/saturncloud/envs/saturn/lib/

--- a/saturn-python-tensorflow/environment.yml
+++ b/saturn-python-tensorflow/environment.yml
@@ -6,13 +6,14 @@ channels:
 dependencies:
     - blas=2.114=mkl
     - bokeh=2.4.3
+    - cudnn=8.1.0
     - cudatoolkit=11.2
     - dask=2022.3.0
     - dask-cuda=22.04
-    - fsspec=2022.3.0
+    - fsspec=2022.5.0
     - ipykernel=6.13.0
     - ipywidgets=7.7.0
-    - keras=2.7.0
+    - keras=2.9.0
     - matplotlib=3.5.2
     - numpy=1.21.6
     - pandas=1.4.2
@@ -21,13 +22,12 @@ dependencies:
     - pyarrow=6.0.1
     - python=3.9
     - python-graphviz=0.20
-    - s3fs=2022.3.0
+    - s3fs>=2021.8.0
     - setuptools<60.0
-    - tensorboard=2.6.0
-    - tensorflow-estimator=2.7.0
-    - tensorflow-gpu=2.7.0=cuda112py39*
+    - tensorboard=2.9.0
     - voila=0.3.5
     - pip:
+          - tensorflow==2.9.1
           - dask-saturn>=0.4.1
           - prefect-saturn>=0.6.0
           - snowflake-connector-python==2.7.7

--- a/saturnbase-python-gpu-11.2/.env_deps
+++ b/saturnbase-python-gpu-11.2/.env_deps
@@ -1,2 +1,2 @@
-VERSION=2022.04.01
-IMAGE=public.ecr.aws/saturncloud/saturnbase-python-gpu-11.2:2022.04.01
+VERSION=2022.06.01
+IMAGE=public.ecr.aws/saturncloud/saturnbase-python-gpu-11.2:2022.06.01.dev


### PR DESCRIPTION
Upgrades TensorFlow to 2.9.1
The install now uses pip and sets the path for LD_LIBARARY_PATH to the correct location to find the conda install