### PR TITLE
add dumb-init

### DIFF
--- a/saturnbase-julia-gpu-11.3/Dockerfile
+++ b/saturnbase-julia-gpu-11.3/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-key del 7fa2af80 && \
     apt-get -qq upgrade -y && \
     apt-get -qq install --yes --no-install-recommends \
     awscli \
+    dumb-init \
     build-essential \
     bzip2 \
     ca-certificates \

--- a/saturnbase-julia/Dockerfile
+++ b/saturnbase-julia/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get -qq --allow-releaseinfo-change update && \
     apt-get -qq upgrade -y && \
     apt-get -qq install --yes --no-install-recommends \
     awscli \
+    dumb-init \
     build-essential \
     bzip2 \
     ca-certificates \

--- a/saturnbase-python-gpu-11.2/Dockerfile
+++ b/saturnbase-python-gpu-11.2/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-key del 7fa2af80 && \
     apt-get -qq upgrade -y && \
     apt-get -qq install --yes --no-install-recommends \
     awscli \
+    dumb-init \
     build-essential \
     bzip2 \
     ca-certificates \

--- a/saturnbase-python-gpu-11.3/Dockerfile
+++ b/saturnbase-python-gpu-11.3/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-key del 7fa2af80 && \
     apt-get -qq upgrade -y && \
     apt-get -qq install --yes --no-install-recommends \
     awscli \
+    dumb-init \
     build-essential \
     bzip2 \
     ca-certificates \

--- a/saturnbase-python/Dockerfile
+++ b/saturnbase-python/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get -qq --allow-releaseinfo-change update && \
     apt-get -qq upgrade -y && \
     apt-get -qq install --yes --no-install-recommends \
     awscli \
+    dumb-init \
     build-essential \
     bzip2 \
     ca-certificates \

--- a/saturnbase-r-bioconductor/Dockerfile
+++ b/saturnbase-r-bioconductor/Dockerfile
@@ -42,6 +42,7 @@ RUN \
     && apt-get upgrade -y \
     && apt-get install --yes --no-install-recommends \
         awscli \
+        dumb-init \
         build-essential \
         bzip2 \
         ca-certificates \

--- a/saturnbase-r-gpu-11.1/Dockerfile
+++ b/saturnbase-r-gpu-11.1/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-key del 7fa2af80 \
     && apt-get upgrade -y \
     && apt-get install --yes --no-install-recommends \
         awscli \
+        dumb-init \
         build-essential \
         bzip2 \
         ca-certificates \

--- a/saturnbase-r/Dockerfile
+++ b/saturnbase-r/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get -qq --allow-releaseinfo-change update \
     && apt-get upgrade -y \
     && apt-get install --yes --no-install-recommends \
         awscli \
+        dumb-init \
         build-essential \
         bzip2 \
         ca-certificates \


### PR DESCRIPTION
dumb-init is the entry point used by saturn2docker images. We don't use them in EKS, but this is necessary for executing docker run.

This is useful for CI/dev/testing for saturn2docker, so that we don't have to install dumb-init into our base images in order to use them.