### PR TITLE
More image cleanup

### DIFF
--- a/saturnbase-julia-gpu-11.3/install-miniconda.bash
+++ b/saturnbase-julia-gpu-11.3/install-miniconda.bash
@@ -10,6 +10,7 @@ set -x && \
     mkdir -p /opt && \
     sh miniconda.sh -b -p /opt/saturncloud && \
     rm miniconda.sh shasum && \
+    /opt/saturncloud/bin/conda install -c conda-forge main::conda=4.13 conda-forge::mamba=0.25 && \
     ln -s /opt/saturncloud/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/saturncloud/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \
@@ -17,5 +18,3 @@ set -x && \
     find /opt/saturncloud/ -follow -type f -name '*.js.map' -delete && \
     /opt/saturncloud/bin/conda clean -afy && \
     chown -R 1000:1000 /opt/saturncloud
-/opt/saturncloud/bin/conda install conda=4.13
-/opt/saturncloud/bin/conda install -c conda-forge mamba=0.25

--- a/saturnbase-julia/install-miniconda.bash
+++ b/saturnbase-julia/install-miniconda.bash
@@ -10,6 +10,7 @@ set -x && \
     mkdir -p /opt && \
     sh miniconda.sh -b -p /opt/saturncloud && \
     rm miniconda.sh shasum && \
+    /opt/saturncloud/bin/conda install -c conda-forge main::conda=4.13 conda-forge::mamba=0.25 && \
     ln -s /opt/saturncloud/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/saturncloud/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \
@@ -17,5 +18,3 @@ set -x && \
     find /opt/saturncloud/ -follow -type f -name '*.js.map' -delete && \
     /opt/saturncloud/bin/conda clean -afy && \
     chown -R 1000:1000 /opt/saturncloud
-/opt/saturncloud/bin/conda install conda=4.13
-/opt/saturncloud/bin/conda install -c conda-forge mamba=0.25

--- a/saturnbase-python-gpu-11.3/install-miniconda.bash
+++ b/saturnbase-python-gpu-11.3/install-miniconda.bash
@@ -10,6 +10,7 @@ set -x && \
     mkdir -p /opt && \
     sh miniconda.sh -b -p /opt/saturncloud && \
     rm miniconda.sh shasum && \
+    /opt/saturncloud/bin/conda install -c conda-forge main::conda=4.13 conda-forge::mamba=0.25 && \
     ln -s /opt/saturncloud/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/saturncloud/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \
@@ -17,5 +18,3 @@ set -x && \
     find /opt/saturncloud/ -follow -type f -name '*.js.map' -delete && \
     /opt/saturncloud/bin/conda clean -afy && \
     chown -R 1000:1000 /opt/saturncloud
-/opt/saturncloud/bin/conda install conda=4.13
-/opt/saturncloud/bin/conda install -c conda-forge mamba=0.25

--- a/saturnbase-python/install-miniconda.bash
+++ b/saturnbase-python/install-miniconda.bash
@@ -10,6 +10,7 @@ set -x && \
     mkdir -p /opt && \
     sh miniconda.sh -b -p /opt/saturncloud && \
     rm miniconda.sh shasum && \
+    /opt/saturncloud/bin/conda install -c conda-forge main::conda=4.13 conda-forge::mamba=0.25 && \
     ln -s /opt/saturncloud/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/saturncloud/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \
@@ -17,5 +18,3 @@ set -x && \
     find /opt/saturncloud/ -follow -type f -name '*.js.map' -delete && \
     /opt/saturncloud/bin/conda clean -afy && \
     chown -R 1000:1000 /opt/saturncloud
-/opt/saturncloud/bin/conda install conda=4.13
-/opt/saturncloud/bin/conda install -c conda-forge mamba=0.25

--- a/saturnbase-r-bioconductor/Dockerfile
+++ b/saturnbase-r-bioconductor/Dockerfile
@@ -137,7 +137,6 @@ RUN Rscript -e "install.packages(c( \
         )"
 
 COPY setup-conda.bash /tmp/setup-conda.bash
-COPY environment.yml /tmp/environment.yml
 
 # Install miniconda
 RUN bash /tmp/setup-conda.bash && \

--- a/saturnbase-r-bioconductor/environment.yml
+++ b/saturnbase-r-bioconductor/environment.yml
@@ -1,6 +1,0 @@
-channels:
-  - defaults
-  - conda-forge
-dependencies:
-  - python
-  - pip

--- a/saturnbase-r-bioconductor/install-miniconda.bash
+++ b/saturnbase-r-bioconductor/install-miniconda.bash
@@ -10,6 +10,7 @@ set -x && \
     mkdir -p /opt && \
     sh miniconda.sh -b -p /opt/saturncloud && \
     rm miniconda.sh shasum && \
+    /opt/saturncloud/bin/conda install -c conda-forge main::conda=4.13 conda-forge::mamba=0.25 && \
     ln -s /opt/saturncloud/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/saturncloud/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \
@@ -17,5 +18,3 @@ set -x && \
     find /opt/saturncloud/ -follow -type f -name '*.js.map' -delete && \
     /opt/saturncloud/bin/conda clean -afy && \
     chown -R 1000:1000 /opt/saturncloud
-/opt/saturncloud/bin/conda install conda=4.13
-/opt/saturncloud/bin/conda install -c conda-forge mamba=0.25

--- a/saturnbase-r-bioconductor/setup-conda.bash
+++ b/saturnbase-r-bioconductor/setup-conda.bash
@@ -7,9 +7,11 @@ cd $(dirname $0)
 
 echo "installing root env:"
 cat /tmp/environment.yml
-conda install -c conda-forge mamba=0.22
 mamba env update -n root  -f /tmp/environment.yml
 
 conda clean -afy
+find ${CONDA_DIR}/ -type f,l -name '*.pyc' -delete
+find ${CONDA_DIR}/ -type f,l -name '*.a' -delete
+find ${CONDA_DIR}/ -type f,l -name '*.js.map' -delete
 
 conda create -n saturn

--- a/saturnbase-r-gpu-11.1/Dockerfile
+++ b/saturnbase-r-gpu-11.1/Dockerfile
@@ -149,7 +149,6 @@ RUN Rscript -e "install.packages(c( \
         )"
 
 COPY setup-conda.bash /tmp/setup-conda.bash
-COPY environment.yml /tmp/environment.yml
 
 # Install miniconda
 RUN bash /tmp/setup-conda.bash && \

--- a/saturnbase-r-gpu-11.1/environment.yml
+++ b/saturnbase-r-gpu-11.1/environment.yml
@@ -1,6 +1,0 @@
-channels:
-  - defaults
-  - conda-forge
-dependencies:
-  - python
-  - pip

--- a/saturnbase-r-gpu-11.1/install-miniconda.bash
+++ b/saturnbase-r-gpu-11.1/install-miniconda.bash
@@ -10,6 +10,7 @@ set -x && \
     mkdir -p /opt && \
     sh miniconda.sh -b -p /opt/saturncloud && \
     rm miniconda.sh shasum && \
+    /opt/saturncloud/bin/conda install -c conda-forge main::conda=4.13 conda-forge::mamba=0.25 && \
     ln -s /opt/saturncloud/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/saturncloud/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \
@@ -17,5 +18,3 @@ set -x && \
     find /opt/saturncloud/ -follow -type f -name '*.js.map' -delete && \
     /opt/saturncloud/bin/conda clean -afy && \
     chown -R 1000:1000 /opt/saturncloud
-/opt/saturncloud/bin/conda install conda=4.13
-/opt/saturncloud/bin/conda install -c conda-forge mamba=0.25

--- a/saturnbase-r-gpu-11.1/setup-conda.bash
+++ b/saturnbase-r-gpu-11.1/setup-conda.bash
@@ -7,8 +7,6 @@ cd $(dirname $0)
 
 echo "installing root env:"
 cat /tmp/environment.yml
-conda install conda=4.13
-conda install -c conda-forge mamba=0.25
 mamba env update -n root  -f /tmp/environment.yml
 
 conda clean -afy

--- a/saturnbase-r/Dockerfile
+++ b/saturnbase-r/Dockerfile
@@ -140,7 +140,6 @@ RUN Rscript -e "install.packages(c( \
         )"
 
 COPY setup-conda.bash /tmp/setup-conda.bash
-COPY environment.yml /tmp/environment.yml
 
 # Install miniconda
 RUN bash /tmp/setup-conda.bash && \

--- a/saturnbase-r/environment.yml
+++ b/saturnbase-r/environment.yml
@@ -1,6 +1,0 @@
-channels:
-  - defaults
-  - conda-forge
-dependencies:
-  - python
-  - pip

--- a/saturnbase-r/install-miniconda.bash
+++ b/saturnbase-r/install-miniconda.bash
@@ -10,6 +10,7 @@ set -x && \
     mkdir -p /opt && \
     sh miniconda.sh -b -p /opt/saturncloud && \
     rm miniconda.sh shasum && \
+    /opt/saturncloud/bin/conda install -c conda-forge main::conda=4.13 conda-forge::mamba=0.25 && \
     ln -s /opt/saturncloud/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/saturncloud/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \
@@ -17,5 +18,3 @@ set -x && \
     find /opt/saturncloud/ -follow -type f -name '*.js.map' -delete && \
     /opt/saturncloud/bin/conda clean -afy && \
     chown -R 1000:1000 /opt/saturncloud
-/opt/saturncloud/bin/conda install conda=4.13
-/opt/saturncloud/bin/conda install -c conda-forge mamba=0.25

--- a/saturnbase-r/setup-conda.bash
+++ b/saturnbase-r/setup-conda.bash
@@ -5,12 +5,6 @@ export PATH="${CONDA_BIN}:${PATH}"
 
 cd $(dirname $0)
 
-echo "installing root env:"
-cat /tmp/environment.yml
-conda install conda=4.13
-conda install -c conda-forge mamba=0.25
-mamba env update -n root  -f /tmp/environment.yml
-
 conda clean -afy
 find ${CONDA_DIR}/ -type f,l -name '*.pyc' -delete
 find ${CONDA_DIR}/ -type f,l -name '*.a' -delete


### PR DESCRIPTION
More image cleanup
    
    - removed some extraneous differences between different R images
    - stopped R images from installing environment.yml, since all those packages (python/pip) are redundant
    - modified install-miniconda.bash to install conda/mamba before cleanup. Also forced channels.

Without this change, the R images don't build.