### PR TITLE
updating tensorflow

### DIFF
--- a/saturn-r-tensorflow/environment.yml
+++ b/saturn-r-tensorflow/environment.yml
@@ -16,4 +16,4 @@ dependencies:
 - scipy
 - python=3.8
 - pip:
-  - tensorflow==2.4.1
+  - tensorflow==2.9.1


### PR DESCRIPTION
tensorflow import is broken because it is too old relative to other python packages.