### PR TITLE
flip back to tensorflow 2.4.1 for R image.

### DIFF
--- a/saturn-r-tensorflow/environment.yml
+++ b/saturn-r-tensorflow/environment.yml
@@ -6,7 +6,7 @@ dependencies:
 - ipykernel
 - ipywidgets
 - matplotlib
-- numpy
+- numpy=1.19.5
 - pandas
 - pip
 - pyarrow
@@ -16,4 +16,4 @@ dependencies:
 - scipy
 - python=3.8
 - pip:
-  - tensorflow==2.9.1
+  - tensorflow==2.4.1


### PR DESCRIPTION
tensorflow 2.9.1 requires cuda 11.2 which we don't have R images for.
For now, stay with 2.4.1, but pin numpy to fix pandas imports

