### PR TITLE
Fix recipe-template field names to match ImageSpecSchema

### DIFF
--- a/saturn-python-312-slim-gpu-12.9/recipe-template.json
+++ b/saturn-python-312-slim-gpu-12.9/recipe-template.json
@@ -1,7 +1,6 @@
 {
-    "recipeName": "saturn-python-312-slim-gpu-12.9",
-    "description": "Python 3.12 GPU slim image with CUDA 12.9 and minimal packages",
-    "image": "saturncloud/saturn-python-slim-gpu:2025.05.01-cuda129-python312",
-    "gpu": true,
-    "saturnVersion": "2025.05.01"
+    "name": "saturn-python-312-slim-gpu-12.9",
+    "description": "Python 3.12 GPU slim image with CUDA 12.9 and minimal packages.",
+    "hardware_type": "gpu",
+    "supports": ["jupyterlab", "dask"]
 }

--- a/saturn-python-312-slim/recipe-template.json
+++ b/saturn-python-312-slim/recipe-template.json
@@ -1,7 +1,6 @@
 {
-    "recipeName": "saturn-python-312-slim",
-    "description": "Python 3.12 slim image with minimal packages",
-    "image": "saturncloud/saturn-python-slim:2025.05.01-python312",
-    "gpu": false,
-    "saturnVersion": "2025.05.01"
+    "name": "saturn-python-312-slim",
+    "description": "Python 3.12 slim image with minimal packages.",
+    "hardware_type": "cpu",
+    "supports": ["jupyterlab", "dask"]
 }

--- a/saturnbase-python-amd-gpu-devel/recipe-template.json
+++ b/saturnbase-python-amd-gpu-devel/recipe-template.json
@@ -1,7 +1,6 @@
 {
-    "recipeName": "saturnbase-python-amd-gpu-devel",
-    "description": "Saturn base Python GPU devel image with rocm7 development tools",
-    "image": "saturncloud/saturnbase-python-amd-gpu-devel:2025.05.01",
-    "gpu": true,
-    "saturnVersion": "2025.05.01"
+    "name": "saturnbase-python-amd-gpu-devel",
+    "description": "Saturn base Python AMD GPU devel image with ROCm 7 development tools.",
+    "hardware_type": "AMD",
+    "supports": ["jupyterlab", "dask"]
 }

--- a/saturnbase-python-gpu-12.9/recipe-template.json
+++ b/saturnbase-python-gpu-12.9/recipe-template.json
@@ -1,7 +1,6 @@
 {
-    "recipeName": "saturnbase-python-gpu-12.9",
-    "description": "Saturn base Python GPU image with CUDA 12.9",
-    "image": "saturncloud/saturnbase-python-gpu-12.9:2025.05.01",
-    "gpu": true,
-    "saturnVersion": "2025.05.01"
+    "name": "saturnbase-python-gpu-12.9",
+    "description": "Python-focused base image for Saturn GPU images, built on CUDA version 12.9. This image contains the minimal install required for the full functionality of Saturn Cloud on a GPU instance, including packages necessary to run Python, JupyterLab, and Dask.",
+    "hardware_type": "gpu",
+    "supports": ["jupyterlab", "dask"]
 }

--- a/saturnbase-python-gpu-devel-12.9/recipe-template.json
+++ b/saturnbase-python-gpu-devel-12.9/recipe-template.json
@@ -1,7 +1,6 @@
 {
-    "recipeName": "saturnbase-python-gpu-devel-12.9",
-    "description": "Saturn base Python GPU devel image with CUDA 12.9 development tools",
-    "image": "saturncloud/saturnbase-python-gpu-devel-12.9:2025.05.01",
-    "gpu": true,
-    "saturnVersion": "2025.05.01"
+    "name": "saturnbase-python-gpu-devel-12.9",
+    "description": "Python-focused base image for Saturn GPU images, built on CUDA version 12.9 with development tools. This image contains the minimal install required for the full functionality of Saturn Cloud on a GPU instance, including packages necessary to run Python, JupyterLab, and Dask.",
+    "hardware_type": "gpu",
+    "supports": ["jupyterlab", "dask"]
 }


### PR DESCRIPTION
## Summary

Five `recipe-template.json` files (CUDA 12.9 base + devel, Python 3.12 slim CPU + GPU, AMD GPU devel) use bogus field names (`recipeName`/`image`/`gpu`/`saturnVersion`) instead of the schema-correct ones (`name`/`description`/`hardware_type`/`supports`). The bad shape was introduced when the 12.4 templates were added in Aug 2025 and copied forward.

When `release-images` uploads these to S3 it stamps them with `schema_version: 2022.03.01`. Saturn's `BaseRecipeSchema.pre_load` treats that as legacy and wraps the top-level body under `spec`, where `ImageSpecSchema` then rejects every field:

```
{'spec': {'name': ['Missing data for required field.'],
          'gpu': ['Unknown field.'],
          'recipeName': ['Unknown field.'],
          'saturnVersion': ['Unknown field.'],
          'image': ['Unknown field.']}}
```

This PR rewrites all five templates to the established shape used by the CUDA 11.8 / 12.1 siblings. The AMD template uses `hardware_type: "AMD"` (validated against `HardwareType.values()` in `pdc/cloud/instances.py`).

## Follow-up

Existing recipes already in S3 will not be healed until the next `release-images` CI run for each of these image prefixes — the uploader pulls the existing recipe, replaces only the matching tag's `versions` entry, and re-uploads.