### PR TITLE
saturn-python-llm: add axolotl 0.16.1

### DIFF
--- a/saturn-python-llm/environment.yml
+++ b/saturn-python-llm/environment.yml
@@ -40,6 +40,9 @@ dependencies:
     - trl
     - peft
     - datasets
+    # Pinned exactly: Token Factory's Atlas renderer is keyed to specific
+    # axolotl YAML field names that change across versions.
+    - axolotl==0.16.1
     - vllm
     - ray
     - sentence-transformers


### PR DESCRIPTION
Adds `axolotl==0.16.1` to `saturn-python-llm/environment.yml` so the in-pod Token Factory fine-tuning shim can invoke `axolotl train <config>` via subprocess.

Pinned exactly to `0.16.1`: Atlas's config renderer is keyed to specific axolotl YAML field names that change across versions, so a loose pin would silently break rendered configs on the next axolotl release.

axolotl depends on `transformers`, `peft`, `accelerate`, `datasets`, `bitsandbytes`, `trl` — all already declared in this environment. CI will surface any version-pin conflicts at build time.

Context: saturncloud/saturn#6394.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>