### PR TITLE
Pin python=3.13 in pytorch and tensorflow envs

### DIFF
--- a/saturn-python-pytorch/environment.yml
+++ b/saturn-python-pytorch/environment.yml
@@ -23,7 +23,7 @@ dependencies:
     - py-opencv
     - pyarrow
     - python-graphviz
-    - python
+    - python=3.13
     - pytorch::pytorch
     - s3fs
     - setuptools

--- a/saturn-python-tensorflow/environment.yml
+++ b/saturn-python-tensorflow/environment.yml
@@ -17,7 +17,7 @@ dependencies:
     - pip
     - prefect
     - pyarrow
-    - python
+    - python=3.13
     - python-graphviz
     - s3fs
     - setuptools


### PR DESCRIPTION
Without an explicit python constraint, mamba now resolves `python=3.14` on conda-forge (released 2025-10-07). That broke both DS envs on `release-2026.05.01` when `release-images` PR #461 retriggered the build:

- **saturn-python-tensorflow**: `pip` can't find `tensorflow[and-cuda]` for `cp314` (no wheels yet), and `snowflake-connector-python` resolves to a `cp314` wheel — the pip step in `mamba env update` fails fast.
- **saturn-python-pytorch**: the multi-channel solve (`pytorch + rapidsai + nvidia + conda-forge`) blows up with `queue count overflow` and `SIGABRT`s after ~2h41m.

Pinning `python=3.13` keeps us close to current while staying on a version every package in the lists ships wheels/builds for. We can revisit 3.14 once `tensorflow[and-cuda]` and the heavy GPU stack catch up.

Failed run for reference: https://github.com/saturncloud/release-images/actions/runs/26549787641

🤖 Generated with [Claude Code](https://claude.com/claude-code)