### PR TITLE
saturn-python-pytorch: PyPI torch on cu129, drop pytorch conda channel

### DIFF
--- a/saturn-python-pytorch/environment.yml
+++ b/saturn-python-pytorch/environment.yml
@@ -1,15 +1,11 @@
 name: saturn
 channels:
-    - pytorch
-    - rapidsai
-    - nvidia
-    - nodefaults
     - conda-forge
+    - nodefaults
 dependencies:
+    - python=3.13
     - blas=*=mkl
     - bokeh
-    - pytorch::pytorch-cuda=12.1
-    - dask-cuda
     - dask
     - fastai
     - fsspec
@@ -23,15 +19,16 @@ dependencies:
     - py-opencv
     - pyarrow
     - python-graphviz
-    - python=3.13
-    - pytorch::pytorch
     - s3fs
     - setuptools
     - tensorboard
-    - pytorch::torchaudio
-    - pytorch::torchvision
     - pynvml
     - pip:
+          - --extra-index-url
+          - https://download.pytorch.org/whl/cu129
+          - torch
+          - torchvision
+          - torchaudio
           - dask-saturn
           - saturn-client
           - saturnfs


### PR DESCRIPTION
The pytorch conda channel was deprecated in October 2024 — 2.5.1 was the last release published there (frozen since 2024-10-23). With the `python=3.13` pin in #471, there are no `pytorch::pytorch` builds left to resolve. The previous build also hit `queue count overflow` and SIGABRTed after 2h41m due to the rapidsai + pytorch + nvidia + conda-forge channel mix.

This PR:

- Drops the `pytorch`, `nvidia`, and `rapidsai` conda channels (and `nodefaults` stays).
- Drops `pytorch::pytorch-cuda`, `pytorch::pytorch`, `pytorch::torchaudio`, `pytorch::torchvision`, and `dask-cuda` (the only thing that pulled in rapidsai).
- Adds `torch` / `torchvision` / `torchaudio` to the pip block with `--extra-index-url https://download.pytorch.org/whl/cu129` — same install path PyTorch now recommends officially.

Pairs with an upcoming release-images change to retarget the `saturn-python-pytorch` build at `saturnbase-python-gpu-12.9` (currently `saturnbase-python-gpu-12.1`). cu129 wheels won't run cleanly on a 12.1 runtime base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)