### PR TITLE
Pin python=3.13 across py images, fix pytorch index-url syntax

### DIFF
--- a/saturn-python-llm/environment.yml
+++ b/saturn-python-llm/environment.yml
@@ -1,14 +1,9 @@
 name: saturn
 channels:
-  - pytorch
-  - nvidia
   - conda-forge
-  - defaults
+  - nodefaults
 dependencies:
-  - python=3.11
-  - cuda-toolkit
-  - pytorch
-  - pytorch-cuda
+  - python=3.13
   - transformers
   - tokenizers
   - numpy
@@ -32,6 +27,10 @@ dependencies:
   - ipykernel
   - pip
   - pip:
+    - --extra-index-url https://download.pytorch.org/whl/cu129
+    - torch
+    - torchvision
+    - torchaudio
     # Fine-tuning stack. unsloth pulls trl/peft/datasets transitively, but we
     # declare them explicitly so the image's training API surface is stable
     # against unsloth version bumps. The Token Factory fine-tune training
@@ -50,7 +49,7 @@ dependencies:
     - bitsandbytes
     - auto-gptq
     - autoawq
-    - https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.0.post2/flash_attn-2.8.0.post2%2Bcu12torch2.7cxx11abiTRUE-cp311-cp311-linux_x86_64.whl
+    - https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.0.post2/flash_attn-2.8.0.post2%2Bcu12torch2.7cxx11abiTRUE-cp313-cp313-linux_x86_64.whl
     - xformers
     - gpustat
     - nvidia-ml-py

--- a/saturn-python-pytorch/environment.yml
+++ b/saturn-python-pytorch/environment.yml
@@ -1,15 +1,11 @@
 name: saturn
 channels:
-    - pytorch
-    - rapidsai
-    - nvidia
-    - nodefaults
     - conda-forge
+    - nodefaults
 dependencies:
+    - python=3.13
     - blas=*=mkl
     - bokeh
-    - pytorch::pytorch-cuda=12.1
-    - dask-cuda
     - dask
     - fastai
     - fsspec
@@ -23,15 +19,15 @@ dependencies:
     - py-opencv
     - pyarrow
     - python-graphviz
-    - python=3.13
-    - pytorch::pytorch
     - s3fs
     - setuptools
     - tensorboard
-    - pytorch::torchaudio
-    - pytorch::torchvision
     - pynvml
     - pip:
+          - --extra-index-url https://download.pytorch.org/whl/cu129
+          - torch
+          - torchvision
+          - torchaudio
           - dask-saturn
           - saturn-client
           - saturnfs

--- a/saturn-python-rapids/environment.yml
+++ b/saturn-python-rapids/environment.yml
@@ -21,7 +21,7 @@ dependencies:
     - prefect
     - pyarrow
     - python-graphviz
-    - python
+    - python=3.13
     - rapids
     - s3fs
     - scikit-learn

--- a/saturn-python/environment.yml
+++ b/saturn-python/environment.yml
@@ -14,7 +14,7 @@ dependencies:
     - pandas
     - pip
     - pyarrow
-    - python=3.11
+    - python=3.13
     - python-graphviz
     - s3fs
     - scikit-learn


### PR DESCRIPTION
Two related cleanups:

**1. Sweep `python=3.13` across all py images.** Without an explicit pin, mamba on conda-forge resolves `python=3.14` (released 2025-10-07). #471 covered pytorch and tensorflow; this picks up the rest:

- **saturn-python** — `python=3.11` → `python=3.13`. Trivial swap.
- **saturn-python-rapids** — was `python` (unpinned), now `python=3.13`. This image was about to hit the same 3.14 failure on the next build.
- **saturn-python-llm** — `python=3.11` → `python=3.13`. Required mirroring the saturn-python-pytorch migration in #472: drop `pytorch` + `nvidia` conda channels (frozen, no cp313 builds for `pytorch`/`pytorch-cuda`); move `torch`/`torchvision`/`torchaudio` to pip via the PyPI `cu129` extra index; swap the pinned `flash_attn` wheel URL from `cp311` → `cp313` (Dao-AILab/flash-attention v2.8.0.post2 already ships a `cu12torch2.7cxx11abiTRUE-cp313-cp313` wheel).

Not touched:
- `saturn-python-312-slim*` — names encode `python312`, already pinned to 3.12.
- R images — python there is secondary tooling, not the image's purpose.

**2. Fix the `--extra-index-url` syntax in saturn-python-pytorch.** #472 wrote it as two separate yml list entries (`- --extra-index-url` then `- https://...`). That's not the conda env yml pip-args grammar — pip parses the first as a bare `--extra-index-url` with no value, then the URL as a positional package spec. Collapsed back to the single-line form.

Heads up on risk: the LLM image change is the load-bearing one. cp313 wheels exist for the big packages (`unsloth`, `vllm`, `accelerate`, `bitsandbytes`, `xformers`, `torch`, `flash_attn`) but `axolotl==0.16.1` and `autoawq`/`auto-gptq` weren't separately verified — they may need a follow-up bump if they don't ship cp313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)