### PR TITLE
saturn-python-llm: pin python=3.12 (axolotl 0.16.1 transitive blocker)

### DIFF
--- a/saturn-python-llm/environment.yml
+++ b/saturn-python-llm/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.13
+  - python=3.12
   - transformers
   - tokenizers
   - numpy
@@ -47,9 +47,7 @@ dependencies:
     - sentence-transformers
     - accelerate
     - bitsandbytes
-    - auto-gptq
-    - autoawq
-    - https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.0.post2/flash_attn-2.8.0.post2%2Bcu12torch2.7cxx11abiTRUE-cp313-cp313-linux_x86_64.whl
+    - https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3%2Bcu12torch2.8cxx11abiTRUE-cp312-cp312-linux_x86_64.whl
     - xformers
     - gpustat
     - nvidia-ml-py


### PR DESCRIPTION
The python=3.13 path from #473 fails for the LLM image because axolotl 0.16.1 unconditionally requires `zstandard==0.22.0`, and that wheel only ships cp310–cp312. Stepping down to `python=3.12` lets the rest of axolotl 0.16.1's pin chain (torch==2.8.0, transformers==5.5.0, accelerate==1.13.0, bitsandbytes==0.49.1, datasets==4.5.0, trl==0.29.0) resolve from pre-built wheels — verified locally.

Also fixes two follow-ups that surfaced while iterating:

- **Drop `auto-gptq` and `autoawq`.** `auto-gptq`'s sdist runs `import torch` at build-deps phase before torch is installed, breaking the env. `autoawq` has the same kind of issue. Neither is referenced anywhere in saturncloud code; vllm handles GPTQ/AWQ checkpoint loading via `compressed-tensors` without these libs.
- **Bump pinned `flash_attn` wheel to v2.8.3 / cu12torch2.8 / cp312.** Axolotl 0.16.1 forces `torch==2.8.0`, but the previously pinned `flash_attn-2.8.0.post2+cu12torch2.7` wheel is ABI-incompatible with torch 2.8 (`undefined symbol: _ZN3c104cuda9SetDeviceEa`). v2.8.3 is also the version axolotl 0.16.1 itself targets under its `flash-attn` extra, so this is a closer fit overall.

Verified locally: env builds clean, all heavy imports succeed (torch, transformers, axolotl, flash_attn, vllm, peft, trl, datasets, accelerate, bitsandbytes). Unsloth's init can't fully run on a CPU-only host (no GPU), but its import path is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)