### PR TITLE
saturn-python-rapids: bump cuda to 12.9, drop dask-sql, pin rapids>=26.02

### DIFF
--- a/saturn-python-rapids/environment.yml
+++ b/saturn-python-rapids/environment.yml
@@ -6,10 +6,9 @@ channels:
     - conda-forge
 dependencies:
     - bokeh
-    - cuda-version=12.0
+    - cuda-version=12.9
     - cvxpy
     - dask-ml
-    - dask-sql
     - dask
     - ipykernel
     - ipywidgets
@@ -22,7 +21,7 @@ dependencies:
     - pyarrow
     - python-graphviz
     - python=3.13
-    - rapids
+    - rapids>=26.02
     - s3fs
     - scikit-learn
     - scipy


### PR DESCRIPTION
Three independent failures in the existing env on `python=3.13`:

- **`cuda-version=12.0`** is no longer in conda-forge (only 12.4+ ships now), so the previous CI build couldn't resolve a CUDA package set at all. Bumping to `12.9` matches the `gpu-12.9` base image we already use for `saturn-python-pytorch`; rapids bundles its own CUDA libs and isn't bound to the base image's CUDA runtime.
- **`dask-sql`** is abandoned upstream and tops out at python 3.12 on conda-forge. Combined with our `python=3.13` sweep it pulled the solver into 2021-era pandas/dask pins. No saturncloud code references `dask-sql`; users who want SQL-on-dask can pip-install it on demand.
- **`rapids` unbounded** resolved to 25.08, which embeds an older `cuml` that broke at import time against the newer `scikit-learn` 1.8 conda-forge ships (`BaseEstimator._get_default_requests` was renamed to `_get_metadata_request`). `rapids>=26.02` resolves to 26.04 with a `cuml` that matches.

Verified locally: env builds clean, all heavy imports (`cudf`, `cuml`, `cupy`, `dask`, `dask_ml`, `sklearn`, `pyarrow`, `cvxpy`, `prefect`, `numba`) succeed.

Final resolved versions: python 3.13, cuda 12.9, rapids 26.04, cudf 26.04, cuml 26.04, sklearn 1.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)