### PR TITLE
saturn-python-llm: pin vllm==0.11.0 (avoid sdist fallback in CI)

### DIFF
--- a/saturn-python-llm/environment.yml
+++ b/saturn-python-llm/environment.yml
@@ -42,7 +42,10 @@ dependencies:
     # Pinned exactly: Token Factory's Atlas renderer is keyed to specific
     # axolotl YAML field names that change across versions.
     - axolotl==0.16.1
-    - vllm
+    # Pinned: vllm walks back through versions otherwise — axolotl 0.16.1 forces
+    # torch==2.8.0, and only 0.10–0.11 satisfy that. Pin to keep CI's pip from
+    # backtracking past wheel-only releases into 0.5.x sdists (which need nvcc).
+    - vllm==0.11.0
     - ray
     - sentence-transformers
     - accelerate


### PR DESCRIPTION
The `-4` build (saturncloud/release-images run 26597595536) failed for the LLM image with:

\`\`\`
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/cuda/bin/nvcc'
ERROR: Failed to build 'vllm' when getting requirements to build wheel
\`\`\`

axolotl 0.16.1 forces `torch==2.8.0`, which narrows the vllm range significantly. CI's pip walked back from vllm 0.21.0 looking for a compatible version, kept walking past 0.11.0's manylinux1 wheel, and eventually fell into a 0.5.x sdist. The sdist needs `nvcc` to build, but the runtime base image (`saturnbase-python-gpu-12.1`) only ships the CUDA runtime, not the dev toolkit.

Locally the same env file lands on `vllm-0.11.0` cleanly — but pip's resolver behavior differs between local and CI under these constraints. Pinning explicitly to `0.11.0` short-circuits the backtracking and keeps resolution wheel-only.

Verified locally: env still builds clean, all heavy imports succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)