### PR TITLE
Pin transformers <5 in saturn-python-llm so vLLM 0.11 boots

### DIFF
--- a/saturn-python-llm/Dockerfile
+++ b/saturn-python-llm/Dockerfile
@@ -6,7 +6,13 @@ RUN sudo apt-get -qq --allow-releaseinfo-change update && \
     libgl1
 
 COPY environment.yml /tmp/environment.yml
+# axolotl 0.16.1 is installed --no-deps so its over-strict transformers==5.5.0
+# metadata pin cannot drag transformers 5.x in and break vLLM 0.11 at boot.
+# Its transitive deps are declared explicitly in environment.yml. This is a
+# separate step because a --no-deps line inside the env.yml pip: block would
+# apply to the whole block, suppressing deps for every pip entry.
 RUN mamba env update -n saturn --file /tmp/environment.yml && \
+    ${CONDA_DIR}/envs/saturn/bin/python -m pip install --no-deps axolotl==0.16.1 && \
     ${CONDA_DIR}/envs/saturn/bin/python -m ipykernel install \
         --name python3 \
         --display-name 'saturn (Python 3)' \

--- a/saturn-python-llm/environment.yml
+++ b/saturn-python-llm/environment.yml
@@ -4,7 +4,12 @@ channels:
   - nodefaults
 dependencies:
   - python=3.12
-  - transformers
+  # vLLM 0.11 boots only on transformers 4.x: transformers 5.x removed
+  # tokenizer.all_special_tokens_extended, which vLLM 0.11 reads at startup,
+  # so 5.x triggers AttributeError -> CrashLoopBackOff. axolotl 0.16.1 runs
+  # fine on transformers 4.57.x at runtime (its metadata pins 5.5.0, but that
+  # is over-strict; see the pip: block where axolotl is installed --no-deps).
+  - transformers>=4.55,<5
   - tokenizers
   - numpy
   - psutil
@@ -39,9 +44,31 @@ dependencies:
     - trl
     - peft
     - datasets
-    # Pinned exactly: Token Factory's Atlas renderer is keyed to specific
-    # axolotl YAML field names that change across versions.
-    - axolotl==0.16.1
+    # Held below transformers 5 to match the conda transformers pin above (the
+    # pip: block is run through pip by `mamba env update`, so repeat the bound
+    # here to stop pip backtracking to 5.x).
+    - transformers>=4.55,<5
+    # axolotl 0.16.1 transitive deps. axolotl itself is installed separately in
+    # the Dockerfile with --no-deps, because its metadata carries an over-strict
+    # `transformers==5.5.0` pin that would otherwise drag transformers 5.x back
+    # in and break vLLM 0.11 at boot. axolotl runs fine on transformers 4.57.x;
+    # its real transitive deps are declared here (and via unsloth/vllm/trl/peft).
+    # NOTE: --no-deps cannot be scoped to a single entry inside this block (pip
+    # applies it to the whole `pip install` invocation), so axolotl is pulled
+    # out into its own `pip install --no-deps axolotl==0.16.1` Dockerfile step.
+    - liger-kernel==0.7.0
+    - lm_eval==0.4.11
+    - fla-core==0.4.1
+    - flash-linear-attention==0.4.1
+    - torchao==0.17.0
+    - optimum==1.16.2
+    - trackio>=0.16.1
+    - schedulefree==1.4.1
+    - axolotl-contribs-lgpl==0.0.7
+    - axolotl-contribs-mit==0.0.6
+    - openenv-core==0.1.0
+    - mistral-common==1.11.0
+    - modal==1.3.0.post1
     # Pinned: vllm walks back through versions otherwise — axolotl 0.16.1 forces
     # torch==2.8.0, and only 0.10–0.11 satisfy that. Pin to keep CI's pip from
     # backtracking past wheel-only releases into 0.5.x sdists (which need nvcc).


### PR DESCRIPTION
## Problem

`saturn-python-llm:2026.05.01` left `transformers` unpinned, which resolved to **5.5.0**. vLLM 0.11.0 reads `tokenizer.all_special_tokens_extended` at startup, and transformers 5.x **removed** that attribute, so the serve pod hits an `AttributeError` and lands in `CrashLoopBackOff`. Every vLLM serve pod built on this image was broken.

## The cross-constraint

We can't just bump vLLM out of the problem:

- `axolotl==0.16.1` (kept exactly pinned — Token Factory's Atlas YAML renderer is keyed to its field names) **forces `torch==2.8.0`**.
- Only **vLLM 0.10–0.11** satisfy torch 2.8.

So vLLM stays at **0.11.0**, and the fix has to come from the transformers side.

## The fix

Pin `transformers>=4.55,<5` — in the conda `dependencies:` and repeated in the `pip:` block (the block is run through pip by `mamba env update`, so the bound has to be present there too to stop pip backtracking to 5.x).

axolotl 0.16.1's metadata carries an over-strict `transformers==5.5.0` pin that would otherwise drag 5.x back in. axolotl runs fine on transformers 4.57.x at runtime, so it is now installed **`--no-deps`** in a separate Dockerfile step, with its real transitive deps declared explicitly in `environment.yml`. (A bare `--no-deps` inside the env.yml `pip:` block applies to the whole `pip install` invocation, suppressing deps for every entry — hence the dedicated Dockerfile step rather than an inline flag.)

## Empirical verification

transformers **4.57.6** was verified to boot vLLM 0.11.0, load Qwen2.5-7B-Instruct + a LoRA adapter, and serve a `/v1/chat/completions` completion.

## After merge

A `release-images` build is needed to publish the rebuilt `saturn-python-llm` image.