### PR TITLE
Add saturn-python-vllm (inference) + saturn-python-axolotl (training), split from saturn-python-llm

### DIFF
--- a/saturn-python-axolotl/Dockerfile
+++ b/saturn-python-axolotl/Dockerfile
@@ -1,0 +1,25 @@
+ARG SATURNBASE_GPU_IMAGE
+FROM ${SATURNBASE_GPU_IMAGE}
+
+RUN sudo apt-get -qq --allow-releaseinfo-change update && \
+    sudo apt-get -qq install --yes --no-install-recommends \
+    libgl1
+
+COPY environment.yml /tmp/environment.yml
+# Unlike the serving image (saturn-python-llm), axolotl is installed WITH its
+# deps here: this image has no vLLM, so there is no transformers<5 constraint to
+# protect, and axolotl 0.16.1 needs the transformers 5.x API at runtime. Letting
+# it resolve its own tree (transformers 5.5, datasets 4.5, trl 0.29, hf-hub>=1,
+# accelerate 1.13, ...) is what makes training actually work. axolotl is declared
+# in environment.yml's pip: block with its extras, so a normal env update pulls
+# everything; no separate --no-deps step.
+RUN mamba env update -n saturn --file /tmp/environment.yml && \
+    ${CONDA_DIR}/envs/saturn/bin/python -m ipykernel install \
+        --name python3 \
+        --display-name 'saturn (Python 3)' \
+        --prefix=${CONDA_DIR} && \
+    ${CONDA_DIR}/bin/conda clean -afy && \
+    find ${CONDA_DIR} -type f,l -name '*.pyc' -delete && \
+    find ${CONDA_DIR} -type f,l -name '*.a' -delete && \
+    find ${CONDA_DIR} -type f,l -name '*.js.map' -delete
+RUN echo '' > ${CONDA_DIR}/envs/saturn/conda-meta/history

--- a/saturn-python-axolotl/Makefile
+++ b/saturn-python-axolotl/Makefile
@@ -1,0 +1,9 @@
+include .env_deps
+export
+
+build_image:
+	docker build \
+		--no-cache \
+		--build-arg SATURNBASE_GPU_IMAGE=${SATURNBASE_GPU_IMAGE} \
+		-t ${IMAGE} \
+		.

--- a/saturn-python-axolotl/environment.yml
+++ b/saturn-python-axolotl/environment.yml
@@ -1,0 +1,53 @@
+name: saturn
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - python=3.12
+  # TRAINING-ONLY image (axolotl). Split out from saturn-python-llm because that
+  # image must pin transformers<5 for vLLM 0.11 serving, but axolotl 0.16.1 is
+  # hard-coupled to the transformers 5.x API (e.g. Trainer.create_optimizer(model=)
+  # — a 5.x-only signature; on 4.57 training dies inside the loop). The two dep
+  # stacks are incompatible in one env, so serving lives in saturn-python-llm and
+  # training lives here. Because there is NO vLLM here, axolotl is installed WITH
+  # its deps (see Dockerfile) — no transformers pin, no --no-deps hack — and it
+  # pulls the correct transformers 5.5 / datasets 4.5 / trl 0.29 / hf-hub>=1 set.
+  - numpy
+  - psutil
+  - pandas
+  - tqdm
+  - click
+  - rich
+  - tensorboard
+  - wandb
+  - ipykernel
+  - pip
+  - pip:
+    - --extra-index-url https://download.pytorch.org/whl/cu129
+    # axolotl 0.16.1 pins torch==2.8.0; install it from the cu129 index so the
+    # GPU build is used (and so the flash-attn wheel below matches torch 2.8).
+    - torch==2.8.0
+    - torchvision
+    - torchaudio
+    # The whole fine-tuning stack. Unlike the serving image, we let axolotl
+    # resolve its own dependency tree (transformers 5.5.0, datasets 4.5.0,
+    # trl 0.29.0, accelerate 1.13.0, peft, hf-hub>=1, etc.) — installed WITH
+    # deps in the Dockerfile. [flash-attn] + [deepspeed] extras for real
+    # multi-GPU LoRA/full fine-tunes; [mlflow] for experiment tracking.
+    - axolotl[flash-attn,deepspeed,mlflow]==0.16.1
+    # flash-attn's build wants torch present at install time; ship the prebuilt
+    # cu12/torch2.8 wheel so it doesn't compile from source (slow, needs nvcc).
+    - https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3%2Bcu12torch2.8cxx11abiTRUE-cp312-cp312-linux_x86_64.whl
+    # Saturn workspace + ops basics (mirror the serving image's tail).
+    - gpustat
+    - black
+    - isort
+    - mypy
+    - pytest
+    - saturn-client
+    # The Token Factory inline training script (pdc/scripts/tf/finetune.py) only
+    # needs requests + PyYAML at runtime; both come in transitively (requests via
+    # axolotl/saturn-client, PyYAML via axolotl). Listed here for clarity / in
+    # case axolotl ever drops them.
+    - requests
+    - pyyaml

--- a/saturn-python-axolotl/recipe-template.json
+++ b/saturn-python-axolotl/recipe-template.json
@@ -1,0 +1,6 @@
+{
+    "name": "saturn-python-axolotl",
+    "description": "Fine-tuning LLMs with axolotl (transformers 5 training stack)",
+    "hardware_type": "gpu",
+    "supports": ["jupyterlab", "dask"]
+}

--- a/saturn-python-vllm/Dockerfile
+++ b/saturn-python-vllm/Dockerfile
@@ -1,0 +1,20 @@
+ARG SATURNBASE_GPU_IMAGE
+FROM ${SATURNBASE_GPU_IMAGE}
+
+RUN sudo apt-get -qq --allow-releaseinfo-change update && \
+    sudo apt-get -qq install --yes --no-install-recommends \
+    libgl1
+
+COPY environment.yml /tmp/environment.yml
+# vLLM serving image. No axolotl here (it lives in saturn-python-axolotl), so the
+# former --no-deps axolotl install step is gone and a plain env update suffices.
+RUN mamba env update -n saturn --file /tmp/environment.yml && \
+    ${CONDA_DIR}/envs/saturn/bin/python -m ipykernel install \
+        --name python3 \
+        --display-name 'saturn (Python 3)' \
+        --prefix=${CONDA_DIR} && \
+    ${CONDA_DIR}/bin/conda clean -afy && \
+    find ${CONDA_DIR} -type f,l -name '*.pyc' -delete && \
+    find ${CONDA_DIR} -type f,l -name '*.a' -delete && \
+    find ${CONDA_DIR} -type f,l -name '*.js.map' -delete
+RUN echo '' > ${CONDA_DIR}/envs/saturn/conda-meta/history

--- a/saturn-python-vllm/Makefile
+++ b/saturn-python-vllm/Makefile
@@ -1,0 +1,9 @@
+include .env_deps
+export
+
+build_image:
+	docker build \
+		--no-cache \
+		--build-arg SATURNBASE_GPU_IMAGE=${SATURNBASE_GPU_IMAGE} \
+		-t ${IMAGE} \
+		.

--- a/saturn-python-vllm/environment.yml
+++ b/saturn-python-vllm/environment.yml
@@ -1,0 +1,62 @@
+name: saturn
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - python=3.12
+  # INFERENCE/SERVING image (vLLM). Split out from the former saturn-python-llm
+  # (which tried to be one image for both training and serving). vLLM 0.11 boots
+  # only on transformers 4.x: transformers 5.x removed
+  # tokenizer.all_special_tokens_extended, which vLLM 0.11 reads at startup, so
+  # 5.x -> AttributeError -> CrashLoopBackOff. Fine-tuning (axolotl, which needs
+  # the transformers 5.x API) now lives in saturn-python-axolotl, so this image
+  # is free to pin transformers<5 without breaking training.
+  - transformers>=4.55,<5
+  - tokenizers
+  - numpy
+  - psutil
+  - pydantic
+  - fastapi
+  - uvicorn
+  - aiohttp
+  - requests
+  - typing-extensions
+  - packaging
+  - filelock
+  - matplotlib
+  - pandas
+  - seaborn
+  - tqdm
+  - click
+  - rich
+  - tensorboard
+  - wandb
+  - ipykernel
+  - pip
+  - pip:
+    - --extra-index-url https://download.pytorch.org/whl/cu129
+    - torch
+    - torchvision
+    - torchaudio
+    # Held below transformers 5 to match the conda pin above (the pip: block is
+    # run through pip by `mamba env update`, so repeat the bound to stop pip
+    # backtracking to 5.x).
+    - transformers>=4.55,<5
+    # vLLM serving stack.
+    - vllm==0.11.0
+    - ray
+    - sentence-transformers
+    # peft so vLLM can load the LoRA adapters Token Factory fine-tunes produce.
+    - peft
+    - accelerate
+    - bitsandbytes
+    - https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3%2Bcu12torch2.8cxx11abiTRUE-cp312-cp312-linux_x86_64.whl
+    - xformers
+    - gpustat
+    - nvidia-ml-py
+    - huggingface-hub
+    - black
+    - isort
+    - mypy
+    - pytest
+    - saturn-client

--- a/saturn-python-vllm/recipe-template.json
+++ b/saturn-python-vllm/recipe-template.json
@@ -1,0 +1,6 @@
+{
+    "name": "saturn-python-vllm",
+    "description": "Serving LLMs with vLLM (inference; transformers 4 stack)",
+    "hardware_type": "gpu",
+    "supports": ["jupyterlab", "dask"]
+}


### PR DESCRIPTION
## Why

**saturn-python-llm** tried to be one image for **both** vLLM serving and axolotl fine-tuning, but those dependency stacks are now incompatible in a single env:

- **vLLM 0.11** boots only on **transformers < 5** (5.x removed `tokenizer.all_special_tokens_extended` → AttributeError → CrashLoopBackOff at startup).
- **axolotl 0.16.1** needs the **transformers 5.x API** — e.g. `Trainer.create_optimizer(model=...)`, a 5.x-only signature. On transformers 4.57 a fine-tune dies *inside the training loop* (verified on the live image; the old image's "axolotl runs fine on 4.57" comment is empirically false).

A method-signature difference can't be pinned around, so split **by engine** (extensible to future inference engines / fine-tuning frameworks):

| image | role | stack |
|---|---|---|
| **saturn-python-vllm** | inference endpoints | vLLM 0.11, **transformers<5**; axolotl-only deps stripped, no `--no-deps` hack |
| **saturn-python-axolotl** | fine-tune jobs | **axolotl 0.16.1 installed WITH deps** → pulls the correct transformers 5.5 / datasets 4.5 / trl 0.29 / hf-hub≥1 stack; `[flash-attn,deepspeed,mlflow]` extras |

Both build on the cu129 GPU base (`saturnbase-python-gpu-12.9`).

## Companion PR

Registered for building in **saturncloud/release-images#480** (adds both to `data_science.py`, `main_release.py`, and the build matrix; wires Atlas `TF_TRAINING_IMAGE_URI` → axolotl and `TF_INFERENCE_IMAGE_URI` → vllm).

`saturn-python-llm` is left in place for now; it can be retired once Atlas points at the split images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)