### PR TITLE
saturn-python-axolotl: drop deepspeed (breaks single-GPU training)

### DIFF
--- a/saturn-python-axolotl/environment.yml
+++ b/saturn-python-axolotl/environment.yml
@@ -32,9 +32,17 @@ dependencies:
     # The whole fine-tuning stack. Unlike the serving image, we let axolotl
     # resolve its own dependency tree (transformers 5.5.0, datasets 4.5.0,
     # trl 0.29.0, accelerate 1.13.0, peft, hf-hub>=1, etc.) — installed WITH
-    # deps in the Dockerfile. [flash-attn] + [deepspeed] extras for real
-    # multi-GPU LoRA/full fine-tunes; [mlflow] for experiment tracking.
-    - axolotl[flash-attn,deepspeed,mlflow]==0.16.1
+    # deps in the Dockerfile. [flash-attn] for attention; [mlflow] for tracking.
+    #
+    # NOTE: deepspeed is deliberately NOT installed. accelerate imports it
+    # unconditionally (in unwrap_model) WHENEVER it's present, and deepspeed's
+    # op-builder probes `nvcc` at import — which this RUNTIME image lacks (nvcc
+    # ships only in -devel bases) — crashing every job, including single-GPU ones
+    # that never use it (verified: without deepspeed, accelerate.unwrap_model
+    # degrades gracefully and axolotl trains). Re-enabling multi-GPU deepspeed is
+    # a follow-up that needs either a -devel base (for nvcc) or a prebuilt-ops
+    # deepspeed; the renderer only emits a deepspeed config for instance_gpus > 1.
+    - axolotl[flash-attn,mlflow]==0.16.1
     # flash-attn's build wants torch present at install time; ship the prebuilt
     # cu12/torch2.8 wheel so it doesn't compile from source (slow, needs nvcc).
     - https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3%2Bcu12torch2.8cxx11abiTRUE-cp312-cp312-linux_x86_64.whl


### PR DESCRIPTION
**Every axolotl fine-tune job crashes at Trainer init** with:
```
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/cuda/bin/nvcc'
  deepspeed/ops/op_builder/builder.py installed_cuda_version() ...
```
because `accelerate.unwrap_model` imports deepspeed **unconditionally when it's installed**, and deepspeed's op-builder probes `nvcc` at import. This runtime image has the CUDA runtime but not `nvcc` (that's `-devel`-only), so it crashes — even for single-GPU jobs that never use deepspeed.

**Fix:** drop the `[deepspeed]` extra. Verified end-to-end on the built `2026.05.01-8` image: with deepspeed removed, `accelerate.unwrap_model` degrades gracefully and axolotl trains a LoRA to completion (`train_loss: 1.55`, adapter saved).

Multi-GPU deepspeed is a follow-up — needs a `-devel` base (for nvcc) or a prebuilt-ops deepspeed. The axolotl renderer only emits a deepspeed config for `instance_gpus > 1`, so single/most jobs are unaffected.

Requires an image rebuild + tag bump to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)