### PR TITLE
Bump axolotl 0.16.1→0.17.0 and vLLM 0.11.0→0.25.1

### DIFF
--- a/saturn-python-axolotl/environment.yml
+++ b/saturn-python-axolotl/environment.yml
@@ -4,14 +4,14 @@ channels:
   - nodefaults
 dependencies:
   - python=3.12
-  # TRAINING-ONLY image (axolotl). Split out from saturn-python-llm because that
-  # image must pin transformers<5 for vLLM 0.11 serving, but axolotl 0.16.1 is
-  # hard-coupled to the transformers 5.x API (e.g. Trainer.create_optimizer(model=)
-  # — a 5.x-only signature; on 4.57 training dies inside the loop). The two dep
-  # stacks are incompatible in one env, so serving lives in saturn-python-llm and
-  # training lives here. Because there is NO vLLM here, axolotl is installed WITH
-  # its deps (see Dockerfile) — no transformers pin, no --no-deps hack — and it
-  # pulls the correct transformers 5.5 / datasets 4.5 / trl 0.29 / hf-hub>=1 set.
+  # TRAINING-ONLY image (axolotl). Split out from the serving image (vLLM) because
+  # the two dep stacks pin different exact versions of transformers/torch/trl and
+  # can't share one env. Training lives here; serving lives in saturn-python-vllm.
+  # Because there is NO vLLM here, axolotl is installed WITH its deps (see
+  # Dockerfile) — no transformers pin, no --no-deps hack — and it pulls its own
+  # consistent tree (axolotl 0.17.0 -> transformers 5.9.0 / datasets 4.8 /
+  # trl 1.5.1 / accelerate 1.13.0 / peft 0.19.1 / hf-hub>=1). peft 0.19.1 matches
+  # the serving image so a LoRA adapter trained here loads in vLLM.
   - numpy
   - psutil
   - pandas
@@ -24,14 +24,14 @@ dependencies:
   - pip
   - pip:
     - --extra-index-url https://download.pytorch.org/whl/cu129
-    # axolotl 0.16.1 pins torch==2.8.0; install it from the cu129 index so the
-    # GPU build is used (and so the flash-attn wheel below matches torch 2.8).
-    - torch==2.8.0
+    # axolotl 0.17.0 pins torch>=2.9.1; install torch 2.9.1 from the cu129 index so
+    # the GPU build is used (and so the flash-attn wheel below matches torch 2.9).
+    - torch==2.9.1
     - torchvision
     - torchaudio
     # The whole fine-tuning stack. Unlike the serving image, we let axolotl
-    # resolve its own dependency tree (transformers 5.5.0, datasets 4.5.0,
-    # trl 0.29.0, accelerate 1.13.0, peft, hf-hub>=1, etc.) — installed WITH
+    # resolve its own dependency tree (transformers 5.9.0, datasets 4.8,
+    # trl 1.5.1, accelerate 1.13.0, peft 0.19.1, hf-hub>=1, etc.) — installed WITH
     # deps in the Dockerfile. [flash-attn] + [deepspeed] extras for real
     # multi-GPU LoRA/full fine-tunes; [mlflow] for experiment tracking.
     #
@@ -43,10 +43,12 @@ dependencies:
     # saturnbase-python-gpu-devel-12.9 (see its dependency in release-images
     # data_science.py). Do NOT switch back to the runtime base without also
     # dropping the [deepspeed] extra.
-    - axolotl[flash-attn,deepspeed,mlflow]==0.16.1
+    - axolotl[flash-attn,deepspeed,mlflow]==0.17.0
     # flash-attn's build wants torch present at install time; ship the prebuilt
-    # cu12/torch2.8 wheel so it doesn't compile from source (slow, needs nvcc).
-    - https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3%2Bcu12torch2.8cxx11abiTRUE-cp312-cp312-linux_x86_64.whl
+    # cu12/torch2.9 wheel so it doesn't compile from source (slow, needs nvcc).
+    # axolotl 0.17.0's [flash-attn] extra still pins flash-attn==2.8.3; the wheel
+    # tag must match the torch version above (torch2.9), not the old torch2.8.
+    - https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3%2Bcu12torch2.9cxx11abiTRUE-cp312-cp312-linux_x86_64.whl
     # Saturn workspace + ops basics (mirror the serving image's tail).
     - gpustat
     - black

--- a/saturn-python-vllm/environment.yml
+++ b/saturn-python-vllm/environment.yml
@@ -4,14 +4,14 @@ channels:
   - nodefaults
 dependencies:
   - python=3.12
-  # INFERENCE/SERVING image (vLLM). Split out from the former saturn-python-llm
-  # (which tried to be one image for both training and serving). vLLM 0.11 boots
-  # only on transformers 4.x: transformers 5.x removed
-  # tokenizer.all_special_tokens_extended, which vLLM 0.11 reads at startup, so
-  # 5.x -> AttributeError -> CrashLoopBackOff. Fine-tuning (axolotl, which needs
-  # the transformers 5.x API) now lives in saturn-python-axolotl, so this image
-  # is free to pin transformers<5 without breaking training.
-  - transformers>=4.55,<5
+  # INFERENCE/SERVING image (vLLM). Split from the training image (axolotl) because
+  # the two stacks pin different exact torch/transformers versions. vLLM 0.25.1
+  # REQUIRES transformers>=5.5.3 and torch==2.11.0 (a hard pin in its metadata) —
+  # the old transformers<5 constraint that forced the split is gone; vLLM 0.25 is
+  # now a transformers-5.x stack too. Kept as a separate image only because it
+  # pins torch 2.11 while axolotl pins torch 2.9. peft is held at 0.19.1 (see the
+  # pip block) to match the training image so LoRA adapters load.
+  - transformers>=5.5.3
   - tokenizers
   - numpy
   - psutil
@@ -35,22 +35,27 @@ dependencies:
   - pip
   - pip:
     - --extra-index-url https://download.pytorch.org/whl/cu129
-    - torch
+    # vLLM 0.25.1 pins torch==2.11.0; install it from the cu129 index for the GPU
+    # build (cu129 carries torch 2.11.0 cp312 wheels).
+    - torch==2.11.0
     - torchvision
     - torchaudio
-    # Held below transformers 5 to match the conda pin above (the pip: block is
-    # run through pip by `mamba env update`, so repeat the bound to stop pip
-    # backtracking to 5.x).
-    - transformers>=4.55,<5
-    # vLLM serving stack.
-    - vllm==0.11.0
+    # Match the conda transformers pin above (the pip: block is run through pip by
+    # `mamba env update`, so repeat the bound). vLLM 0.25.1 needs transformers>=5.5.3.
+    - transformers>=5.5.3
+    # vLLM serving stack. vLLM 0.25.1 uses flashinfer (pulled in transitively as
+    # flashinfer-python) as its attention backend — no hand-shipped flash-attn
+    # wheel needed here anymore (the old torch2.8 wheel would also be wrong for
+    # torch 2.11).
+    - vllm==0.25.1
     - ray
     - sentence-transformers
     # peft so vLLM can load the LoRA adapters Token Factory fine-tunes produce.
-    - peft
+    # Pinned to match the training image (axolotl 0.17.0 resolves peft 0.19.1) so
+    # an adapter trained there loads here.
+    - peft==0.19.1
     - accelerate
     - bitsandbytes
-    - https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3%2Bcu12torch2.8cxx11abiTRUE-cp312-cp312-linux_x86_64.whl
     - xformers
     - gpustat
     - nvidia-ml-py


### PR DESCRIPTION
Upgrades the two split Token Factory images to expand fine-tunable (axolotl) and serveable (vLLM) model coverage. Both `environment.yml` stacks were resolved metadata-only (`uv pip compile --index-strategy unsafe-best-match`) before submitting — each solves cleanly with no conflict.

## saturn-python-axolotl (training) — axolotl 0.16.1 → 0.17.0
- Pulls transformers 5.9.0, trl 1.5.1, peft 0.19.1, accelerate 1.13.0, deepspeed 0.18.9, datasets 4.8.
- torch 2.8.0 → **2.9.1** (axolotl 0.17.0 pins `torch>=2.9.1`); cu129 index carries `torch-2.9.1+cu129-cp312`.
- flash-attn wheel retagged `torch2.8` → **`torch2.9`** (axolotl 0.17.0's `[flash-attn]` extra still pins `flash-attn==2.8.3`; only the torch tag changes). Wheel confirmed present in the v2.8.3 release.
- Keeps the gpu-devel base (deepspeed still needs nvcc — unchanged).

## saturn-python-vllm (serving) — vLLM 0.11.0 → 0.25.1
- `transformers>=4.55,<5` → **`>=5.5.3`** (conda line + pip block); vLLM 0.25.1 requires `transformers>=5.5.3`. The old "vLLM needs transformers 4.x" comment is rewritten.
- torch pinned **`==2.11.0`** (vLLM 0.25.1's hard pin); cu129 index carries `torch-2.11.0+cu129-cp312`.
- **Dropped the hand-shipped flash-attn wheel** — vLLM 0.25.1 uses flashinfer (`flashinfer-python`, pulled transitively) as its attention backend; the old torch2.8 wheel would be wrong for torch 2.11 anyway.
- `peft` pinned **`==0.19.1`** to match the training image.

## Contracts / notes
- **The two images stay split**, but the *reason* changed: the old transformers 4-vs-5 conflict is gone (both are transformers-5.x now). They're split only because they pin different torch versions (axolotl 2.9.1, vLLM 2.11.0).
- **peft 0.19.1 on both images** — a LoRA adapter trained by axolotl loads in vLLM serving (the train→serve contract). Verified in both resolves.
- **Atlas-side follow-ups (separate, not in this PR):** the Token Factory model catalog (`SUPPORTED_MODELS` / the axolotl chat-template map in `axolotl_config.py`, vLLM-served arch list) and any code that references vLLM 0.11-specific behavior (`max_lora_rank` accepted set, and the vLLM Prometheus metric names the serving-metrics feature queries) should be re-checked against 0.25.1 before the new images ship.

Resolved-set proof (metadata-only): both stacks solve; key pins — axolotl: `axolotl==0.17.0 / torch==2.9.1+cu129 / transformers==5.9.0 / flash-attn==2.8.3(torch2.9) / peft==0.19.1`; vLLM: `vllm==0.25.1 / torch==2.11.0+cu129 / transformers==5.13.1 / flashinfer-python==0.6.13 / peft==0.19.1`. The CUDA-op build is proven by the release-images build.