### PR TITLE
CUDA 13 bases: prefer conda libstdc++ (fix vLLM CXXABI_1.3.15 crash)

### DIFF
--- a/saturnbase-python-gpu-13.3/Dockerfile
+++ b/saturnbase-python-gpu-13.3/Dockerfile
@@ -72,6 +72,15 @@ RUN bash /tmp/install-jupyter.bash && \
     ${CONDA_BIN}/conda config --system --set show_channel_urls true
 ENV NB_PYTHON_PREFIX ${CONDA_DIR}/envs/saturn
 ENV PATH ${NB_PYTHON_PREFIX}/bin:${CONDA_BIN}:${HOME}/.local/bin:${PATH}
+# Prefer the conda env's libstdc++ over the CUDA base's system one. The
+# nvidia/cuda:13.3-ubuntu22.04 base ships an older system libstdc++ (max
+# CXXABI_1.3.13); newer compiled wheels (e.g. scipy's _highspy, pulled in by
+# vLLM's transformers import chain) need CXXABI_1.3.15, which the conda env's
+# libstdcxx-ng DOES provide. Without this, `vllm serve` crashes at import with
+# `libstdc++.so.6: version CXXABI_1.3.15 not found`. (On the CUDA-12 bases this
+# was masked because torch/libcudart failed earlier; on CUDA 13 the import gets
+# far enough to hit it.)
+ENV LD_LIBRARY_PATH ${NB_PYTHON_PREFIX}/lib:${CONDA_DIR}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 WORKDIR ${HOME}
 ENTRYPOINT []
 

--- a/saturnbase-python-gpu-devel-13.3/Dockerfile
+++ b/saturnbase-python-gpu-devel-13.3/Dockerfile
@@ -72,6 +72,15 @@ RUN bash /tmp/install-jupyter.bash && \
     ${CONDA_BIN}/conda config --system --set show_channel_urls true
 ENV NB_PYTHON_PREFIX ${CONDA_DIR}/envs/saturn
 ENV PATH ${NB_PYTHON_PREFIX}/bin:${CONDA_BIN}:${HOME}/.local/bin:${PATH}
+# Prefer the conda env's libstdc++ over the CUDA base's system one. The
+# nvidia/cuda:13.3-ubuntu22.04 base ships an older system libstdc++ (max
+# CXXABI_1.3.13); newer compiled wheels (e.g. scipy's _highspy, pulled in by
+# vLLM's transformers import chain) need CXXABI_1.3.15, which the conda env's
+# libstdcxx-ng DOES provide. Without this, `vllm serve` crashes at import with
+# `libstdc++.so.6: version CXXABI_1.3.15 not found`. (On the CUDA-12 bases this
+# was masked because torch/libcudart failed earlier; on CUDA 13 the import gets
+# far enough to hit it.)
+ENV LD_LIBRARY_PATH ${NB_PYTHON_PREFIX}/lib:${CONDA_DIR}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 WORKDIR ${HOME}
 ENTRYPOINT []
 


### PR DESCRIPTION
Second CUDA-13 issue, surfaced live on tf-demo once the `libcudart.so.13` fix let vLLM import further.

**Symptom:** `vllm serve` on the CUDA-13 image crashes at startup:
```
ImportError: /lib/x86_64-linux-gnu/libstdc++.so.6: version `CXXABI_1.3.15' not found
(required by .../scipy/optimize/_highspy/_core...so)
```
(vLLM's import chain: `transformers → scipy.optimize → _highspy`.)

**Root cause:** `nvidia/cuda:13.3.0-cudnn-*-ubuntu22.04` ships a system libstdc++ whose newest CXXABI is 1.3.13. The conda env's `libstdcxx-ng` HAS 1.3.15 — but the bases set `PATH` for the env and never `LD_LIBRARY_PATH`, so the CUDA base's older system libstdc++ won for compiled extensions. (Masked on the CUDA-12 bases because torch/libcudart failed earlier in the chain.)

**Fix:** prepend the conda env lib dir to `LD_LIBRARY_PATH` in both -13.3 bases (runtime + devel).

**Verified empirically** on the live `saturn-python-vllm:2026.05.01-11` image: with this `LD_LIBRARY_PATH`, `vllm serve` imports cleanly through to device detection (CXXABI error gone), and CUDA libs still resolve (torch 2.11.0+cu130 loads, reaches GPU detection).

**Contracts:** none — env var on the base images only. After merge, needs an images tag + DS bump (→ -12) to rebuild vLLM/axolotl on the fixed bases.

https://claude.ai/code/session_01SctQRVmxhCJgMxKGACPVRb