### PR TITLE
saturn-python-axolotl: add boto3 (TF adapter S3 upload)

### DIFF
--- a/saturn-python-axolotl/environment.yml
+++ b/saturn-python-axolotl/environment.yml
@@ -65,3 +65,7 @@ dependencies:
     # case axolotl ever drops them.
     - requests
     - pyyaml
+    # finetune.py also uploads the trained LoRA adapter to the TF adapter store
+    # (S3-compatible) — that upload needs boto3, which nothing pulls in
+    # transitively.
+    - boto3


### PR DESCRIPTION
The TF fine-tune training image lacks boto3, so `pdc/scripts/tf/finetune.py`'s adapter S3 upload fails with "No module named 'boto3'" (live-verified on tf-staging). The upload is non-fatal, so training completes but the trained LoRA adapter never reaches the adapter store — shared-tier serving of fresh checkpoints is dead on arrival. This adds boto3 (unpinned, matching the file's loose deps) to the pip section of the axolotl environment.

Contracts: none — dependency addition only.

https://claude.ai/code/session_01PM4iV7xek6wdDZZTJgGLW5